### PR TITLE
fix(ci): stabilize npm publish registry and auth preflight

### DIFF
--- a/.github/actions/publish-npm/action.yml
+++ b/.github/actions/publish-npm/action.yml
@@ -15,11 +15,22 @@ runs:
         export NODE_OPTIONS
         yarn workspaces changed list
 
+    - name: Verify NPM auth
+      shell: bash
+      run: |
+        source .env
+        export NODE_OPTIONS
+        yarn npm whoami --publish
+      env:
+        YARN_NPM_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}
+        YARN_NPM_PUBLISH_REGISTRY: https://registry.npmjs.org
+
     - name: Npm Publish
       shell: bash
       run: |
         source .env
         export NODE_OPTIONS
-        yarn workspaces changed foreach -vt --no-private npm publish --access public
+        yarn workspaces changed foreach -vt --no-private npm publish --tolerate-republish --access public
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}
+        YARN_NPM_PUBLISH_REGISTRY: https://registry.npmjs.org

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   run:
     name: Publish
+    if: ${{ github.event.pull_request.merged == true }}
     env:
       NODE_VERSION: '22'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Таска
- Close atls/planning#206
- Refs atls/planning#203

## Как проверять
До фикса на `master`: проверить тот же publish flow по реальному run-логу
```bash
curl -sS -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" https://api.github.com/repos/atls/raijin/actions/jobs/69581841577/logs | rg -n "Request URL|YN0035|registry.yarnpkg.com"
```

После фикса на head branch PR: проверить тот же publish flow в workflow/action конфиге
```bash
git fetch origin
```

```bash
git checkout fix/publish-npm-registry
```

```bash
rg -n "merged == true" .github/workflows/publish.yaml
```

```bash
rg -n "whoami --publish|--tolerate-republish|YARN_NPM_PUBLISH_REGISTRY" .github/actions/publish-npm/action.yml
```

```bash
source .env
```

```bash
export NODE_OPTIONS
```

```bash
YARN_NPM_AUTH_TOKEN="$NPM_TOKEN" YARN_NPM_PUBLISH_REGISTRY="https://registry.npmjs.org" node .yarn/releases/yarn.mjs npm whoami --publish
```

## Пруфы
Publish to NPM (до фикса)
raw request
```text
PUT https://registry.yarnpkg.com/@atls%2fcode-format
```
raw response
```text
YN0035 Not found
Response Code: 404 (Not Found)
Run: https://github.com/atls/raijin/actions/runs/23865064844/job/69581841577
```

Publish action/config (после фикса)
raw request
```text
yarn npm whoami --publish
```
raw response
```text
В action выставлен publish registry: https://registry.npmjs.org
Добавлен tolerate mode: --tolerate-republish
```
