### PR TITLE
fix(ci): use existing npm auth secret in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -56,7 +56,7 @@ jobs:
         id: npm
         uses: ./.github/actions/publish-npm
         with:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPMAUTHTOKEN }}
 
       - name: Bundle yarn
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Таска
- Close atls/planning#206
- Refs atls/planning#203

## Как проверять
До фикса на `master`: тот же publish flow
```bash
/usr/local/bin/gh run view 23865064844 --repo atls/raijin --job 69590163508 --log | rg -n "YN0041|whoami --publish|Publish to NPM"
```

После фикса на head branch PR: тот же workflow-конфиг
```bash
git fetch origin
```

```bash
git checkout fix/publish-npm-registry
```

```bash
rg -n "NPMAUTHTOKEN|NPM_TOKEN" .github/workflows/publish.yaml
```

```bash
/usr/local/bin/gh run rerun 23865064844 --repo atls/raijin
```

## Пруфы
Publish to NPM (до фикса)
raw request
```text
yarn npm whoami --publish
```
raw response
```text
YN0041: Invalid authentication (as an unknown user)
Run: https://github.com/atls/raijin/actions/runs/23865064844/job/69590163508
```

Publish workflow config (после фикса)
raw request
```text
with:
  NPM_TOKEN: ${{ secrets.NPMAUTHTOKEN }}
```
raw response
```text
Workflow использует существующий секрет репозитория NPMAUTHTOKEN
```
