### PR TITLE
fix(tools): keep root language switch in repository root

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # Atlantis Raijin
 
-[![Raijin Docs RU](https://img.shields.io/badge/Raijin%20Docs-RU-0b5fff)](docs/README.ru.md)
-[![Raijin Docs EN](https://img.shields.io/badge/Raijin%20Docs-EN-1f8a70)](docs/README.md)
+[![Raijin Docs RU](https://img.shields.io/badge/Raijin%20Docs-RU-0b5fff)](README_RU.md)
+[![Raijin Docs EN](https://img.shields.io/badge/Raijin%20Docs-EN-1f8a70)](README.md)
 
 <!-- sync:root-what -->
 
@@ -79,8 +79,10 @@ Expected result:
 
 ## Where to read next
 
-- RU (default): [docs/README.ru.md](docs/README.ru.md)
-- EN: [docs/README.md](docs/README.md)
+- RU (default): [README_RU.md](README_RU.md)
+- EN: [README.md](README.md)
+- Docs index RU: [docs/README.ru.md](docs/README.ru.md)
+- Docs index EN: [docs/README.md](docs/README.md)
 - Raijin section router: [docs/raijin/README.md](docs/raijin/README.md)
 - Quickstart: [docs/raijin/quickstart.md](docs/raijin/quickstart.md)
 - Commands map: [docs/raijin/commands.md](docs/raijin/commands.md)

--- a/README_RU.md
+++ b/README_RU.md
@@ -2,8 +2,8 @@
 
 # Atlantis Raijin
 
-[![Raijin Docs RU](https://img.shields.io/badge/Raijin%20Docs-RU-0b5fff)](docs/README.ru.md)
-[![Raijin Docs EN](https://img.shields.io/badge/Raijin%20Docs-EN-1f8a70)](docs/README.md)
+[![Raijin Docs RU](https://img.shields.io/badge/Raijin%20Docs-RU-0b5fff)](README_RU.md)
+[![Raijin Docs EN](https://img.shields.io/badge/Raijin%20Docs-EN-1f8a70)](README.md)
 
 <!-- sync:root-what -->
 
@@ -79,8 +79,10 @@ yarn test unit
 
 ## Где читать дальше
 
-- RU (по умолчанию): [docs/README.ru.md](docs/README.ru.md)
-- EN: [docs/README.md](docs/README.md)
+- RU (по умолчанию): [README_RU.md](README_RU.md)
+- EN: [README.md](README.md)
+- Индекс документации RU: [docs/README.ru.md](docs/README.ru.md)
+- Индекс документации EN: [docs/README.md](docs/README.md)
 - Роутер раздела Raijin: [docs/raijin/README.ru.md](docs/raijin/README.ru.md)
 - Быстрый старт: [docs/raijin/quickstart.ru.md](docs/raijin/quickstart.ru.md)
 - Карта команд: [docs/raijin/commands.ru.md](docs/raijin/commands.ru.md)

--- a/scripts/raijin/generate-artifacts.mjs
+++ b/scripts/raijin/generate-artifacts.mjs
@@ -442,6 +442,8 @@ const linkByLanguage = (basePath, language) => `${basePath}${language === 'ru' ?
 
 const renderRootReadme = (language) => {
   const isRu = language === 'ru'
+  const rootReadmeRu = 'README_RU.md'
+  const rootReadmeEn = 'README.md'
   const docsRouterRu = 'docs/README.ru.md'
   const docsRouterEn = 'docs/README.md'
   const quickstartPath = linkByLanguage('docs/raijin/quickstart', language)
@@ -454,8 +456,8 @@ const renderRootReadme = (language) => {
     '',
     '# Atlantis Raijin',
     '',
-    `[![Raijin Docs RU](https://img.shields.io/badge/Raijin%20Docs-RU-0b5fff)](${docsRouterRu})`,
-    `[![Raijin Docs EN](https://img.shields.io/badge/Raijin%20Docs-EN-1f8a70)](${docsRouterEn})`,
+    `[![Raijin Docs RU](https://img.shields.io/badge/Raijin%20Docs-RU-0b5fff)](${rootReadmeRu})`,
+    `[![Raijin Docs EN](https://img.shields.io/badge/Raijin%20Docs-EN-1f8a70)](${rootReadmeEn})`,
     '',
     '<!-- sync:root-what -->',
     '',
@@ -559,9 +561,15 @@ const renderRootReadme = (language) => {
     isRu ? '## Где читать дальше' : '## Where to read next',
     '',
     isRu
-      ? `- RU (по умолчанию): [docs/README.ru.md](${docsRouterRu})`
-      : `- RU (default): [docs/README.ru.md](${docsRouterRu})`,
-    isRu ? `- EN: [docs/README.md](${docsRouterEn})` : `- EN: [docs/README.md](${docsRouterEn})`,
+      ? `- RU (по умолчанию): [README_RU.md](${rootReadmeRu})`
+      : `- RU (default): [README_RU.md](${rootReadmeRu})`,
+    isRu ? `- EN: [README.md](${rootReadmeEn})` : `- EN: [README.md](${rootReadmeEn})`,
+    isRu
+      ? `- Индекс документации RU: [docs/README.ru.md](${docsRouterRu})`
+      : `- Docs index RU: [docs/README.ru.md](${docsRouterRu})`,
+    isRu
+      ? `- Индекс документации EN: [docs/README.md](${docsRouterEn})`
+      : `- Docs index EN: [docs/README.md](${docsRouterEn})`,
     isRu
       ? `- Роутер раздела Raijin: [${raijinRouterPath}](${raijinRouterPath})`
       : `- Raijin section router: [${raijinRouterPath}](${raijinRouterPath})`,


### PR DESCRIPTION
## Таска

- Refs atls/planning#207

## Как проверять

Экран: Корневой `README.md` репозитория в GitHub
Что нажать: бейдж `Raijin Docs RU`
Что должно произойти: открывается `README_RU.md` в корне репозитория, а не `docs/README.ru.md`

Экран: Корневой `README_RU.md` репозитория в GitHub
Что нажать: бейдж `Raijin Docs EN`
Что должно произойти: открывается `README.md` в корне репозитория

Экран: Блок `Где читать дальше` в `README_RU.md`
Что нажать: ссылку `Индекс документации RU`
Что должно произойти: открывается `docs/README.ru.md`

Экран: Блок `Where to read next` в `README.md`
Что нажать: ссылку `Docs index EN`
Что должно произойти: открывается `docs/README.md`

## Пруфы

- `yarn raijin:generate` выполнился успешно
- `yarn raijin:check:localization` выполнился успешно
- `yarn raijin:check:coverage` выполнился успешно
- `yarn raijin:smoke:deterministic` выполнился успешно
- Корневые бейджи RU/EN теперь ведут на `README_RU.md` и `README.md`
