### PR TITLE
fix(tools): align RU-first docs routing and quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 [![Raijin Docs RU](https://img.shields.io/badge/Raijin%20Docs-RU-0b5fff)](README_RU.md)
 [![Raijin Docs EN](https://img.shields.io/badge/Raijin%20Docs-EN-1f8a70)](README.md)
 
+<!-- sync:root-language-default -->
+
+Default docs language is RU: [README_RU.md](README_RU.md). EN version: [README.md](README.md)
+
 <!-- sync:root-what -->
 
 ## What this is
@@ -60,7 +64,6 @@ Expected result:
 ```bash
 yarn check
 yarn files changed list
-yarn test unit
 ```
 
 Expected result:

--- a/README_RU.md
+++ b/README_RU.md
@@ -5,6 +5,10 @@
 [![Raijin Docs RU](https://img.shields.io/badge/Raijin%20Docs-RU-0b5fff)](README_RU.md)
 [![Raijin Docs EN](https://img.shields.io/badge/Raijin%20Docs-EN-1f8a70)](README.md)
 
+<!-- sync:root-language-default -->
+
+Документация по умолчанию: [README_RU.md](README_RU.md). Английская версия: [README.md](README.md)
+
 <!-- sync:root-what -->
 
 ## Что это
@@ -60,7 +64,6 @@ yarn set version atls
 ```bash
 yarn check
 yarn files changed list
-yarn test unit
 ```
 
 Ожидаемый результат:

--- a/docs/raijin/quickstart.md
+++ b/docs/raijin/quickstart.md
@@ -6,10 +6,9 @@ Minimal install-and-verify flow for the custom `atls` Yarn bundle
 
 ## 1. Prerequisites
 
-- Node.js: `22.x`
-- Yarn: `4.x`
+- Node.js: `>= 22`
+- Yarn: `>= 4`
 - A working project with `package.json`
-- Internet access to download bundle artifacts
 
 Expected result:
 
@@ -27,7 +26,7 @@ yarn set version atls
 Expected result:
 
 - `.yarn/releases/` contains the current Raijin `yarn.mjs`
-- Bundle commands (`check`, `files changed list`, `test unit`, etc.) become available
+- Bundle commands (`check`, `files changed list`, etc.) become available
 
 <!-- sync:bundle-upgrade -->
 
@@ -48,14 +47,12 @@ Expected result:
 ```bash
 yarn check
 yarn files changed list
-yarn test unit
 ```
 
 Expected result:
 
 - `yarn check` runs a complete validation pass without routing errors
 - `yarn files changed list` returns file list (or empty list if no changes)
-- `yarn test unit` runs unit tests for the current project
 
 <!-- sync:consumer-howto -->
 
@@ -64,16 +61,3 @@ Expected result:
 - Install once, then keep it current with `yarn set version atls`
 - Commit `.yarn/releases` and `.yarnrc.yml` changes together with bundle updates
 - Use the same commands in CI and locally to avoid behavior drift
-
-<!-- sync:inside-raijin -->
-
-## 6. Extra: working inside `raijin`
-
-```bash
-source .env
-export NODE_OPTIONS
-```
-
-Expected result:
-
-- Internal repository commands run in a consistent environment

--- a/docs/raijin/quickstart.ru.md
+++ b/docs/raijin/quickstart.ru.md
@@ -6,10 +6,9 @@
 
 ## 1. Предпосылки
 
-- Node.js: `22.x`
-- Yarn: `4.x`
+- Node.js: `>= 22` (не ниже `22`)
+- Yarn: `>= 4` (не ниже `4`)
 - Рабочий проект с `package.json`
-- Доступ к интернету для загрузки bundle-файла
 
 Ожидаемый результат:
 
@@ -27,7 +26,7 @@ yarn set version atls
 Ожидаемый результат:
 
 - В `.yarn/releases/` появляется актуальный `yarn.mjs` из Raijin
-- Команды из бандла (`check`, `files changed list`, `test unit` и другие) становятся доступны
+- Команды из бандла (`check`, `files changed list` и другие) становятся доступны
 
 <!-- sync:bundle-upgrade -->
 
@@ -48,14 +47,12 @@ yarn set version atls
 ```bash
 yarn check
 yarn files changed list
-yarn test unit
 ```
 
 Ожидаемый результат:
 
 - `yarn check` завершает полный проход проверок без ошибок маршрутизации
 - `yarn files changed list` возвращает список файлов или пустой список, если изменений нет
-- `yarn test unit` запускает модульные тесты текущего проекта
 
 <!-- sync:consumer-howto -->
 
@@ -64,16 +61,3 @@ yarn test unit
 - Подключите бандл один раз, затем поддерживайте версию через `yarn set version atls`
 - Коммитьте изменения `.yarn/releases` и `.yarnrc.yml` вместе с обновлением бандла
 - Для CI используйте те же команды, что и локально, чтобы избежать расхождения поведения
-
-<!-- sync:inside-raijin -->
-
-## 6. Дополнительно: работа внутри `raijin`
-
-```bash
-source .env
-export NODE_OPTIONS
-```
-
-Ожидаемый результат:
-
-- Внутренние команды репозитория выполняются в согласованной среде

--- a/scripts/raijin/generate-artifacts.mjs
+++ b/scripts/raijin/generate-artifacts.mjs
@@ -459,6 +459,12 @@ const renderRootReadme = (language) => {
     `[![Raijin Docs RU](https://img.shields.io/badge/Raijin%20Docs-RU-0b5fff)](${rootReadmeRu})`,
     `[![Raijin Docs EN](https://img.shields.io/badge/Raijin%20Docs-EN-1f8a70)](${rootReadmeEn})`,
     '',
+    '<!-- sync:root-language-default -->',
+    '',
+    isRu
+      ? `Документация по умолчанию: [README_RU.md](${rootReadmeRu}). Английская версия: [README.md](${rootReadmeEn})`
+      : `Default docs language is RU: [README_RU.md](${rootReadmeRu}). EN version: [README.md](${rootReadmeEn})`,
+    '',
     '<!-- sync:root-what -->',
     '',
     isRu ? '## Что это' : '## What this is',
@@ -534,7 +540,6 @@ const renderRootReadme = (language) => {
     '```bash',
     'yarn check',
     'yarn files changed list',
-    'yarn test unit',
     '```',
     '',
     isRu ? 'Ожидаемый результат:' : 'Expected result:',
@@ -721,12 +726,9 @@ const renderQuickstart = (language) => {
     '<!-- sync:preflight -->',
     isRu ? '## 1. Предпосылки' : '## 1. Prerequisites',
     '',
-    '- Node.js: `22.x`',
-    '- Yarn: `4.x`',
+    isRu ? '- Node.js: `>= 22` (не ниже `22`)' : '- Node.js: `>= 22`',
+    isRu ? '- Yarn: `>= 4` (не ниже `4`)' : '- Yarn: `>= 4`',
     isRu ? '- Рабочий проект с `package.json`' : '- A working project with `package.json`',
-    isRu
-      ? '- Доступ к интернету для загрузки bundle-файла'
-      : '- Internet access to download bundle artifacts',
     '',
     isRu ? 'Ожидаемый результат:' : 'Expected result:',
     isRu
@@ -746,8 +748,8 @@ const renderQuickstart = (language) => {
       ? '- В `.yarn/releases/` появляется актуальный `yarn.mjs` из Raijin'
       : '- `.yarn/releases/` contains the current Raijin `yarn.mjs`',
     isRu
-      ? '- Команды из бандла (`check`, `files changed list`, `test unit` и другие) становятся доступны'
-      : '- Bundle commands (`check`, `files changed list`, `test unit`, etc.) become available',
+      ? '- Команды из бандла (`check`, `files changed list` и другие) становятся доступны'
+      : '- Bundle commands (`check`, `files changed list`, etc.) become available',
     '',
     '<!-- sync:bundle-upgrade -->',
     isRu ? '## 3. Обновление установленного бандла' : '## 3. Upgrade installed bundle',
@@ -767,7 +769,6 @@ const renderQuickstart = (language) => {
     '```bash',
     'yarn check',
     'yarn files changed list',
-    'yarn test unit',
     '```',
     '',
     isRu ? 'Ожидаемый результат:' : 'Expected result:',
@@ -777,9 +778,6 @@ const renderQuickstart = (language) => {
     isRu
       ? '- `yarn files changed list` возвращает список файлов или пустой список, если изменений нет'
       : '- `yarn files changed list` returns file list (or empty list if no changes)',
-    isRu
-      ? '- `yarn test unit` запускает модульные тесты текущего проекта'
-      : '- `yarn test unit` runs unit tests for the current project',
     '',
     '<!-- sync:consumer-howto -->',
     isRu ? '## 5. Как использовать в чужом проекте' : '## 5. How to use in an external project',
@@ -793,19 +791,6 @@ const renderQuickstart = (language) => {
     isRu
       ? '- Для CI используйте те же команды, что и локально, чтобы избежать расхождения поведения'
       : '- Use the same commands in CI and locally to avoid behavior drift',
-    '',
-    '<!-- sync:inside-raijin -->',
-    isRu ? '## 6. Дополнительно: работа внутри `raijin`' : '## 6. Extra: working inside `raijin`',
-    '',
-    '```bash',
-    'source .env',
-    'export NODE_OPTIONS',
-    '```',
-    '',
-    isRu ? 'Ожидаемый результат:' : 'Expected result:',
-    isRu
-      ? '- Внутренние команды репозитория выполняются в согласованной среде'
-      : '- Internal repository commands run in a consistent environment',
     '',
   ].join('\n')
 }


### PR DESCRIPTION
## Таска

- Refs atls/planning#207

## Как проверять

Экран: Корневой `README.md` репозитория
Что нажать: бейдж `Raijin Docs RU`
Что должно произойти: открывается корневой `README_RU.md`, а не страница из `docs/`

Экран: Корневой `README_RU.md` репозитория
Что нажать: бейдж `Raijin Docs EN`
Что должно произойти: открывается корневой `README.md`

Экран: `docs/raijin/quickstart.ru.md`, раздел `1. Предпосылки`
Что нажать: открыть раздел и сверить пункты
Что должно произойти: указаны минимумы `Node.js >= 22` и `Yarn >= 4`, отсутствует пункт про интернет

Экран: `docs/raijin/quickstart.ru.md`, раздел `4. Базовая проверка`
Что нажать: открыть блок команд
Что должно произойти: используются `yarn check` и `yarn files changed list`, без `yarn test unit`

Экран: `docs/raijin/quickstart.ru.md`
Что нажать: просмотреть структуру разделов
Что должно произойти: отсутствует блок `6. Дополнительно: работа внутри raijin`

## Пруфы

- Генератор обновил корневые `README.md` и `README_RU.md` с явным указанием, что RU — документация по умолчанию
- В `quickstart.ru.md` обновлены предпосылки (`>= 22`, `>= 4`) и удалён пункт про интернет
- В `quickstart.ru.md` из базовой проверки убран `yarn test unit`
- Удалён блок про локальную внутреннюю среду `raijin` из quickstart
- Локальные проверки: `raijin:check:localization`, `raijin:check:coverage`, `raijin:smoke:deterministic`
