### PR TITLE
fix(tools): clarify root readme positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,12 @@
 [![Raijin Docs RU](https://img.shields.io/badge/Raijin%20Docs-RU-0b5fff)](README.md)
 [![Raijin Docs EN](https://img.shields.io/badge/Raijin%20Docs-EN-1f8a70)](README_EN.md)
 
-<!-- sync:root-language-default -->
-
-Документация по умолчанию: [README.md](README.md). Английская версия: [README_EN.md](README_EN.md)
-
 <!-- sync:root-what -->
 
 ## Что это
 
-Raijin — это набор команд и пакетов для монорепозиториев, поставляемый как кастомный Yarn-бандл `atls`
-Цель — дать единый способ запускать проверки, сборку, релиз и сервисные утилиты в разных проектах
+Raijin — это подход к работе в едином инженерном контуре, поставляемый как кастомный Yarn-бандл `atls`
+Он объединяет команды вокруг строгих стандартов и мощных контрактов, чтобы повышать предсказуемость поставки и реальную производительность
 
 <!-- sync:root-audience -->
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -5,16 +5,12 @@
 [![Raijin Docs RU](https://img.shields.io/badge/Raijin%20Docs-RU-0b5fff)](README.md)
 [![Raijin Docs EN](https://img.shields.io/badge/Raijin%20Docs-EN-1f8a70)](README_EN.md)
 
-<!-- sync:root-language-default -->
-
-Default docs language is RU: [README.md](README.md). EN version: [README_EN.md](README_EN.md)
-
 <!-- sync:root-what -->
 
 ## What this is
 
-Raijin is a command and package toolkit for monorepos, shipped as the custom `atls` Yarn bundle
-The goal is one consistent way to run checks, builds, release, and utility flows across projects
+Raijin is an engineering operating model for a unified delivery contour, shipped as the custom `atls` Yarn bundle
+It aligns teams on strict standards and strong contracts to increase delivery predictability and real engineering throughput
 
 <!-- sync:root-audience -->
 

--- a/scripts/raijin/generate-artifacts.mjs
+++ b/scripts/raijin/generate-artifacts.mjs
@@ -459,22 +459,16 @@ const renderRootReadme = (language) => {
     `[![Raijin Docs RU](https://img.shields.io/badge/Raijin%20Docs-RU-0b5fff)](${rootReadmeRu})`,
     `[![Raijin Docs EN](https://img.shields.io/badge/Raijin%20Docs-EN-1f8a70)](${rootReadmeEn})`,
     '',
-    '<!-- sync:root-language-default -->',
-    '',
-    isRu
-      ? `Документация по умолчанию: [README.md](${rootReadmeRu}). Английская версия: [README_EN.md](${rootReadmeEn})`
-      : `Default docs language is RU: [README.md](${rootReadmeRu}). EN version: [README_EN.md](${rootReadmeEn})`,
-    '',
     '<!-- sync:root-what -->',
     '',
     isRu ? '## Что это' : '## What this is',
     '',
     isRu
-      ? 'Raijin — это набор команд и пакетов для монорепозиториев, поставляемый как кастомный Yarn-бандл `atls`'
-      : 'Raijin is a command and package toolkit for monorepos, shipped as the custom `atls` Yarn bundle',
+      ? 'Raijin — это подход к работе в едином инженерном контуре, поставляемый как кастомный Yarn-бандл `atls`'
+      : 'Raijin is an engineering operating model for a unified delivery contour, shipped as the custom `atls` Yarn bundle',
     isRu
-      ? 'Цель — дать единый способ запускать проверки, сборку, релиз и сервисные утилиты в разных проектах'
-      : 'The goal is one consistent way to run checks, builds, release, and utility flows across projects',
+      ? 'Он объединяет команды вокруг строгих стандартов и мощных контрактов, чтобы повышать предсказуемость поставки и реальную производительность'
+      : 'It aligns teams on strict standards and strong contracts to increase delivery predictability and real engineering throughput',
     '',
     '<!-- sync:root-audience -->',
     '',


### PR DESCRIPTION
## Таска

- https://github.com/atls/raijin/pull/541

## Как проверять

1. Переключиться на ветку ПР

```bash
git checkout fix/readme-philosophy
```

2. Перегенерировать артефакты документации

```bash
yarn raijin:generate
```

3. Проверить синхронизацию локализаций

```bash
yarn raijin:check:localization
```

4. Прогнать детерминированный смоук

```bash
yarn raijin:smoke:deterministic
```

5. Открыть корневые ридми и проверить содержимое вручную

```bash
sed -n '1,40p' README.md
sed -n '1,40p' README_EN.md
```

## Пруфы

- Удалена строка `Документация по умолчанию: README.md. Английская версия: README_EN.md` из корневого `README.md` и `README_EN.md`
- Блок `Что это / What this is` переписан: акцент на единый инженерный контур, строгие стандарты и мощные контракты
- Результаты локальных проверок:

```text
yarn raijin:check:localization
Localization sync check passed
```

```text
yarn raijin:smoke:deterministic
Deterministic smoke passed (8 cases)
```
