### PR TITLE
fix(github): run raijin llm smoke on master pushes

### DIFF
--- a/.github/workflows/raijin-llm-smoke.yml
+++ b/.github/workflows/raijin-llm-smoke.yml
@@ -1,8 +1,9 @@
 name: Raijin LLM Smoke
 
 on:
-  schedule:
-    - cron: '0 2 * * *'
+  push:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       model:


### PR DESCRIPTION
## Таска

- Close atls/raijin#543

## Как проверять

1. Переключиться на ветку ПР

```bash
git checkout fix/llm-smoke-post-merge
```

2. Проверить триггеры workflow

```bash
sed -n '1,20p' .github/workflows/raijin-llm-smoke.yml
```

3. Убедиться, что в файле нет `schedule` и есть `push` на `master`

```bash
rg -n "^on:|schedule:|push:|branches:|master" .github/workflows/raijin-llm-smoke.yml
```

## Пруфы

- Изменён только один файл: `.github/workflows/raijin-llm-smoke.yml`
- Ночной `cron` удалён
- Добавлен запуск по `push` в `master`
- `workflow_dispatch` оставлен

```text
git diff -- .github/workflows/raijin-llm-smoke.yml
@@
-on:
-  schedule:
-    - cron: '0 2 * * *'
+on:
+  push:
+    branches:
+      - master
```
