### PR TITLE
fix(cli-ui-lint-result): remove extra vertical spacing

### DIFF
--- a/cli/cli-ui-lint-result/src/lint-result-message.component.tsx
+++ b/cli/cli-ui-lint-result/src/lint-result-message.component.tsx
@@ -42,7 +42,7 @@ export const LintResultMessage = ({
     </Box>
     {!!source && (
       <>
-        <Box marginBottom={1}>
+        <Box>
           <SourcePreview line={message.line} column={message.column}>
             {source}
           </SourcePreview>

--- a/cli/cli-ui-lint-result/src/lint-result.component.test.tsx
+++ b/cli/cli-ui-lint-result/src/lint-result.component.test.tsx
@@ -40,7 +40,6 @@ import React             from 'react'
 │  3 |                                                                                             │
 │  4 | import { render }        from 'ink-testing-library'                                         │
 │                                                                                                  │
-│                                                                                                  │
 │   some message                                                                                   │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯`


### PR DESCRIPTION
## Таска
- Close atls/raijin#555

## Как проверять
### До фикса
1. Контекст: CLI вывод lint-result
Действие: запустить lint на файле с ошибкой и source preview
Ожидаемый результат: между source preview и текстом сообщения есть лишняя пустая строка

### После фикса
1. Контекст: CLI вывод lint-result
Действие: запустить lint на файле с ошибкой и source preview
Ожидаемый результат: сообщение рендерится сразу под source preview без дополнительной пустой строки

## Пруфы
- unit test: `yarn test unit --test-reporter=tap /Volumes/KINGSTON/workspace/atls/raijin/cli/cli-ui-lint-result/src/lint-result.component.test.tsx`
- измененные файлы:
  - `cli/cli-ui-lint-result/src/lint-result-message.component.tsx`
  - `cli/cli-ui-lint-result/src/lint-result.component.test.tsx`