### PR TITLE
fix(code-icons): handle missing replacements

### DIFF
--- a/code/code-icons/src/icons.test.ts
+++ b/code/code-icons/src/icons.test.ts
@@ -1,0 +1,98 @@
+import assert     from 'node:assert/strict'
+import { test }   from 'node:test'
+
+import type { Config } from '@atls/code-runtime/svgr'
+
+import { Icons }  from './icons.js'
+
+type ReplaceAttrValues = Record<string, string>
+
+type IconFixture = {
+  source: string
+  path: string
+  name: string
+  component: string
+}
+
+type TransformConfig = Partial<Config> & {
+  replaceAttrValues?: ReplaceAttrValues
+}
+
+class TestIcons extends Icons {
+  constructor(
+    private readonly replacementsFixture: Record<string, ReplaceAttrValues>,
+    onTransform: (config: TransformConfig) => Promise<string>
+  ) {
+    super(
+      {
+        transform: (async (_source: string, config: TransformConfig) =>
+          onTransform(config)) as never,
+        jsx: (() => null) as never,
+      },
+      (() => {
+        throw new Error('Webpack should not be used in this test')
+      }) as never,
+      { tsLoader: '' },
+      process.cwd()
+    )
+  }
+
+  async runTransform(icons: Array<IconFixture>): Promise<void> {
+    await this.transform(icons, {})
+  }
+
+  protected override async compileReplacementsAndTemplate(): Promise<{
+    replacements: Record<string, ReplaceAttrValues>
+    template: Config['template']
+  }> {
+    return {
+      replacements: this.replacementsFixture,
+      template: undefined as unknown as Config['template'],
+    }
+  }
+}
+
+test('should pass empty replacements when replacement entry is missing', async () => {
+  const replaceAttrValuesCalls: Array<ReplaceAttrValues | undefined> = []
+
+  const icons = new TestIcons({}, async ({ replaceAttrValues }) => {
+    replaceAttrValuesCalls.push(replaceAttrValues)
+
+    return 'export const MissingReplacementIcon = () => null'
+  })
+
+  await icons.runTransform([
+    {
+      source: '<svg />',
+      path: '/tmp/missing-replacement.svg',
+      name: 'missing-replacement',
+      component: 'MissingReplacement',
+    },
+  ])
+
+  assert.deepEqual(replaceAttrValuesCalls, [{}])
+})
+
+test('should pass configured replacements when replacement entry exists', async () => {
+  const replaceAttrValuesCalls: Array<ReplaceAttrValues | undefined> = []
+  const replacement: ReplaceAttrValues = {
+    '#000': 'currentColor',
+  }
+
+  const icons = new TestIcons({ ExistingReplacementIcon: replacement }, async ({ replaceAttrValues }) => {
+    replaceAttrValuesCalls.push(replaceAttrValues)
+
+    return 'export const ExistingReplacementIcon = () => null'
+  })
+
+  await icons.runTransform([
+    {
+      source: '<svg />',
+      path: '/tmp/existing-replacement.svg',
+      name: 'existing-replacement',
+      component: 'ExistingReplacement',
+    },
+  ])
+
+  assert.deepEqual(replaceAttrValuesCalls, [replacement])
+})

--- a/code/code-icons/src/icons.ts
+++ b/code/code-icons/src/icons.ts
@@ -122,7 +122,7 @@ export class Icons extends EventEmitter {
             template,
             typescript: true,
             expandProps: true,
-            replaceAttrValues: replacements[`${icon.component}Icon`],
+            replaceAttrValues: replacements[`${icon.component}Icon`] ?? {},
           },
           {
             componentName: `${icon.component}Icon`,


### PR DESCRIPTION
## Таска
- Close atls/raijin#553

## Как проверять
### До фикса
1. Контекст: генерация иконок (`yarn ui icons generate`)
Действие: запустить генерацию, когда в replacements нет entry для части иконок
Ожидаемый результат: генерация может падать из-за `replaceAttrValues` = `undefined`

### После фикса
1. Контекст: генерация иконок (`yarn ui icons generate`)
Действие: запустить генерацию с неполным replacements-конфигом
Ожидаемый результат: генерация не падает, для отсутствующего entry используется пустой объект replacements

## Пруфы
- unit test: `yarn test unit --test-reporter=tap /Volumes/KINGSTON/workspace/atls/raijin/code/code-icons/src/icons.test.ts`
- lint: `yarn lint code/code-icons/src/icons.ts code/code-icons/src/icons.test.ts`
- измененные файлы:
  - `code/code-icons/src/icons.ts`
  - `code/code-icons/src/icons.test.ts`