### PR TITLE
fix(github): serialize publish workflow runs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,10 @@ on:
     paths-ignore:
       - '.github/**'
 
+concurrency:
+  group: publish-master
+  cancel-in-progress: false
+
 jobs:
   run:
     name: Publish


### PR DESCRIPTION
## Task
- https://github.com/atls/raijin/actions/runs/24962726693/job/73092090998
- https://github.com/atls/raijin/actions/runs/24962738138

## Changes
- added workflow-level `concurrency` to `Publish` in `.github/workflows/publish.yaml`
- set `group: publish-master`
- set `cancel-in-progress: false` so parallel publish runs are queued, not executed concurrently

## How to test
1. Trigger two `Publish` runs for `master` in a short interval
2. Ensure the second run is queued until the first finishes
3. Ensure there are no race failures like `Expected branch to point to ...`
4. Ensure there are no duplicate-release failures like `already_exists` caused by parallel execution

## Proofs
- root-cause confirmed from failed run logs in Task links
- workflow YAML validated locally:
  - `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/publish.yaml'); puts 'ok'"`
