### PR TITLE
fix(common): reconcile published version drift

### DIFF
--- a/code/code-icons/CHANGELOG.md
+++ b/code/code-icons/CHANGELOG.md
@@ -1,5 +1,11 @@
 
 
+## [2.0.24](https://github.com/atls/raijin/compare/@atls/code-icons@2.0.23...@atls/code-icons@2.0.24) (2026-04-26)
+
+
+
+
+
 ## [2.0.23](https://github.com/atls/raijin/compare/@atls/code-icons@2.0.22...@atls/code-icons@2.0.23) (2026-04-23)
 
 

--- a/code/code-icons/package.json
+++ b/code/code-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atls/code-icons",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "license": "BSD-3-Clause",
   "type": "module",
   "exports": {

--- a/yarn/plugin-ui/CHANGELOG.md
+++ b/yarn/plugin-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 
 
+## [1.0.18](https://github.com/atls/raijin/compare/@atls/yarn-plugin-ui@1.0.17...@atls/yarn-plugin-ui@1.0.18) (2026-04-26)
+
+
+
+
+
 ## [1.0.17](https://github.com/atls/raijin/compare/@atls/yarn-plugin-ui@1.0.16...@atls/yarn-plugin-ui@1.0.17) (2026-04-23)
 
 

--- a/yarn/plugin-ui/package.json
+++ b/yarn/plugin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atls/yarn-plugin-ui",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "private": true,
   "license": "BSD-3-Clause",
   "type": "module",


### PR DESCRIPTION
## Task
- https://github.com/atls/raijin/actions/runs/24962726693/job/73092090998
- https://github.com/atls/raijin/actions/runs/24962738138

## Changes
- aligned repository versions with already published releases:
  - `@atls/code-icons` -> `2.0.24`
  - `@atls/yarn-plugin-ui` -> `1.0.18`
- added missing changelog entries:
  - `code/code-icons/CHANGELOG.md` for `2.0.24`
  - `yarn/plugin-ui/CHANGELOG.md` for `1.0.18`

## How to test
1. Check package versions in repo:
   - `code/code-icons/package.json` is `2.0.24`
   - `yarn/plugin-ui/package.json` is `1.0.18`
2. Check changelog headers for both new versions
3. Run recovery-check (repo vs releases) and ensure result is `ok`

## Proofs
- release tags exist:
  - `@atls/code-icons@2.0.24`
  - `@atls/yarn-plugin-ui@1.0.18`
- npm registry check:
  - `npm view @atls/code-icons@2.0.24 version` -> `2.0.24`
- recovery-check after changes:
  - script result: `ok`
