### PR TITLE
fix(raijin): stabilize llm smoke fallback

### DIFF
--- a/scripts/raijin/run-llm-smoke.mjs
+++ b/scripts/raijin/run-llm-smoke.mjs
@@ -633,6 +633,7 @@ for (const testCase of llmCases) {
 
   const passed =
     !modelCallFailed &&
+    !invalidModelDecision &&
     (testCase.expectedStatus === 'unavailable'
       ? finalDecision.status === 'unavailable'
       : finalDecision.command === testCase.expectedCommand &&

--- a/scripts/raijin/run-llm-smoke.mjs
+++ b/scripts/raijin/run-llm-smoke.mjs
@@ -483,8 +483,9 @@ const normalizeModelDecision = (parsed, shortlistMap) => {
   const command = typeof parsed.command === 'string' ? parsed.command.trim() : ''
   const rawStatus = typeof parsed.status === 'string' ? parsed.status.trim() : ''
   const status = rawStatus === 'inactive' ? 'unavailable' : rawStatus
+  const commandUnavailable = normalizeToken(command) === 'unavailable'
 
-  if (!command) {
+  if (!command || (commandUnavailable && status === 'unavailable')) {
     if (status === 'unavailable') {
       return {
         valid: true,
@@ -632,7 +633,6 @@ for (const testCase of llmCases) {
 
   const passed =
     !modelCallFailed &&
-    !invalidModelDecision &&
     (testCase.expectedStatus === 'unavailable'
       ? finalDecision.status === 'unavailable'
       : finalDecision.command === testCase.expectedCommand &&


### PR DESCRIPTION
## Таска

- Стабилизирует `Raijin LLM Smoke` после merge, когда модель возвращает `{"command":"unavailable","status":"unavailable"}` при наличии корректного active fallback.
- Сохраняет fail-fast для действительно invalid model decisions, например command вне shortlist.

## Как проверять

- `yarn prettier --check scripts/raijin/run-llm-smoke.mjs --config .prettierrc.mjs`
- `yarn raijin:check`
- Mock OpenAI response: `{"command":"unavailable","status":"unavailable"}` для всех LLM smoke cases
- Mock OpenAI response: `{"command":"not in shortlist","status":"active"}` должен падать как `command_not_in_shortlist`

## Пруфы

- `Checking formatting... All matched files use Prettier code style!`
- `Deterministic smoke passed (8 cases)`
- `LLM smoke passed (7 cases, model=gpt-5.4-mini)` на локальном mock OpenAI server с проблемным unavailable-ответом
- Invalid command mock failed as expected with code `1`
