### PR TITLE
fix(yarn): avoid corepack in proxy script env

### DIFF
--- a/yarn/plugin-checks/sources/checks-lint.command.tsx
+++ b/yarn/plugin-checks/sources/checks-lint.command.tsx
@@ -62,7 +62,7 @@ class ChecksLintCommand extends BaseCommand {
       stdout: this.context.stdout,
       stderr: this.context.stderr,
       env: {
-        ...(await scriptUtils.makeScriptEnv({ binFolder, project })),
+        ...(await scriptUtils.makeScriptEnv({ binFolder, project, ignoreCorepack: true })),
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })

--- a/yarn/plugin-checks/sources/checks-release.command.ts
+++ b/yarn/plugin-checks/sources/checks-release.command.ts
@@ -46,7 +46,7 @@ class ChecksReleaseCommand extends BaseCommand {
       stdout: this.context.stdout,
       stderr: this.context.stderr,
       env: {
-        ...(await scriptUtils.makeScriptEnv({ binFolder, project })),
+        ...(await scriptUtils.makeScriptEnv({ binFolder, project, ignoreCorepack: true })),
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })

--- a/yarn/plugin-checks/sources/checks-run.command.ts
+++ b/yarn/plugin-checks/sources/checks-run.command.ts
@@ -6,6 +6,8 @@ import { Configuration }     from '@yarnpkg/core'
 import { MessageName }       from '@yarnpkg/core'
 import { Project }           from '@yarnpkg/core'
 import { execUtils }         from '@yarnpkg/core'
+import { scriptUtils }       from '@yarnpkg/core'
+import { xfs }               from '@yarnpkg/fslib'
 import { Option }            from 'clipanion'
 
 class ChecksRunCommand extends BaseCommand {
@@ -23,15 +25,15 @@ class ChecksRunCommand extends BaseCommand {
         configuration,
       },
       async (report) => {
-        await this.runCheck(project.cwd, ['typecheck'], report)
-        await this.runCheck(project.cwd, ['lint'], report)
+        await this.runCheck(project, project.cwd, ['typecheck'], report)
+        await this.runCheck(project, project.cwd, ['lint'], report)
 
         await Promise.allSettled([
-          this.runCheck(project.cwd, ['test', 'unit'], report),
-          this.runCheck(project.cwd, ['test', 'integration'], report),
+          this.runCheck(project, project.cwd, ['test', 'unit'], report),
+          this.runCheck(project, project.cwd, ['test', 'integration'], report),
         ])
 
-        await this.runCheck(project.cwd, ['release'], report)
+        await this.runCheck(project, project.cwd, ['release'], report)
       }
     )
 
@@ -39,6 +41,7 @@ class ChecksRunCommand extends BaseCommand {
   }
 
   private async runCheck(
+    project: Project,
     cwd: PortablePath,
     args: Array<string>,
     report: StreamReport
@@ -49,9 +52,12 @@ class ChecksRunCommand extends BaseCommand {
         (args[0] === 'lint' || args[0] === 'typecheck') &&
         !args.includes('--changed')
       const checkArgs = shouldAppendChanged ? [...args, '--changed'] : args
+      const binFolder = await xfs.mktempPromise()
+      const env = await scriptUtils.makeScriptEnv({ binFolder, project, ignoreCorepack: true })
 
       const { stdout, stderr } = await execUtils.execvp('yarn', ['checks', ...checkArgs], {
         cwd,
+        env,
       })
 
       this.context.stdout.write(stdout || stderr)

--- a/yarn/plugin-checks/sources/checks-test-integration.command.ts
+++ b/yarn/plugin-checks/sources/checks-test-integration.command.ts
@@ -38,7 +38,7 @@ class ChecksTestIntegrationCommand extends AbstractChecksTestCommand {
 
     const binFolder = await xfs.mktempPromise()
 
-    const env = await scriptUtils.makeScriptEnv({ binFolder, project })
+    const env = await scriptUtils.makeScriptEnv({ binFolder, project, ignoreCorepack: true })
 
     if (!env.NODE_OPTIONS?.includes('@atls/code-runtime/ts-node-register')) {
       env.NODE_OPTIONS = `${env.NODE_OPTIONS ?? ''} --loader @atls/code-runtime/ts-node-register`

--- a/yarn/plugin-checks/sources/checks-test-unit.command.ts
+++ b/yarn/plugin-checks/sources/checks-test-unit.command.ts
@@ -38,7 +38,7 @@ export class ChecksTestUnitCommand extends AbstractChecksTestCommand {
 
     const binFolder = await xfs.mktempPromise()
 
-    const env = await scriptUtils.makeScriptEnv({ binFolder, project })
+    const env = await scriptUtils.makeScriptEnv({ binFolder, project, ignoreCorepack: true })
 
     if (!env.NODE_OPTIONS?.includes('@atls/code-runtime/ts-node-register')) {
       env.NODE_OPTIONS = `${env.NODE_OPTIONS ?? ''} --loader @atls/code-runtime/ts-node-register`

--- a/yarn/plugin-checks/sources/checks-typecheck.command.tsx
+++ b/yarn/plugin-checks/sources/checks-typecheck.command.tsx
@@ -60,7 +60,7 @@ class ChecksTypeCheckCommand extends BaseCommand {
       stdout: this.context.stdout,
       stderr: this.context.stderr,
       env: {
-        ...(await scriptUtils.makeScriptEnv({ binFolder, project })),
+        ...(await scriptUtils.makeScriptEnv({ binFolder, project, ignoreCorepack: true })),
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })

--- a/yarn/plugin-checks/sources/proxy-corepack-env.guard.test.js
+++ b/yarn/plugin-checks/sources/proxy-corepack-env.guard.test.js
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict'
+import { readdir } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
+import { stat } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { extname } from 'node:path'
+import { join } from 'node:path'
+import { relative } from 'node:path'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test } from 'node:test'
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx'])
+
+const TARGET_SOURCE_DIRS = [
+  'yarn/plugin-typescript/sources',
+  'yarn/plugin-lint/sources',
+  'yarn/plugin-checks/sources',
+  'yarn/plugin-test/sources',
+  'yarn/plugin-library/sources',
+  'yarn/plugin-service/sources',
+  'yarn/plugin-ui/sources',
+  'yarn/plugin-tools/sources',
+  'yarn/plugin-renderer/sources',
+]
+
+const YARN_REENTRY_REGEXP =
+  /\b(?:execUtils\.)?(?:pipevp|execvp)\(\s*['"]yarn['"]|\bspawn\(\s*['"]yarn['"]/g
+
+const SCRIPT_ENV_REGEXP = /scriptUtils\.makeScriptEnv\(\s*\{[\s\S]*?\}\s*\)/g
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+
+const getLine = (source, index) => source.slice(0, index).split('\n').length
+
+const collectSourceFiles = async (dir) => {
+  const entries = await readdir(dir)
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(dir, entry)
+      const pathStat = await stat(path)
+
+      if (pathStat.isDirectory()) {
+        return collectSourceFiles(path)
+      }
+
+      if (SOURCE_EXTENSIONS.has(extname(path))) {
+        return [path]
+      }
+
+      return []
+    })
+  )
+
+  return files.flat()
+}
+
+test('should keep yarn proxy re-entry calls isolated from Corepack', async () => {
+  const sourceFiles = (
+    await Promise.all(TARGET_SOURCE_DIRS.map((dir) => collectSourceFiles(join(repoRoot, dir))))
+  ).flat()
+  const sources = await Promise.all(
+    sourceFiles.map(async (path) => ({
+      path,
+      source: await readFile(path, 'utf-8'),
+    }))
+  )
+
+  const errors = []
+
+  for (const { path, source } of sources) {
+    const relativePath = relative(repoRoot, path)
+
+    for (const match of source.matchAll(SCRIPT_ENV_REGEXP)) {
+      if (!match[0].includes('ignoreCorepack: true')) {
+        errors.push(
+          `${relativePath}:${getLine(source, match.index ?? 0)} makeScriptEnv must set ignoreCorepack: true`
+        )
+      }
+    }
+
+    for (const match of source.matchAll(YARN_REENTRY_REGEXP)) {
+      const line = getLine(source, match.index ?? 0)
+      const reentryCall = source.slice(match.index ?? 0, (match.index ?? 0) + 800)
+
+      if (!source.includes('scriptUtils.makeScriptEnv')) {
+        errors.push(`${relativePath}:${line} yarn re-entry must use scriptUtils.makeScriptEnv`)
+      }
+
+      if (!source.includes('ignoreCorepack: true')) {
+        errors.push(`${relativePath}:${line} yarn re-entry must set ignoreCorepack: true`)
+      }
+
+      if (!/env\s*(?:[:,}])/.test(reentryCall)) {
+        errors.push(`${relativePath}:${line} yarn re-entry must pass env to the child process`)
+      }
+    }
+  }
+
+  assert.deepEqual(errors, [])
+})

--- a/yarn/plugin-library/sources/library-build.command.tsx
+++ b/yarn/plugin-library/sources/library-build.command.tsx
@@ -56,7 +56,7 @@ export class LibraryBuildCommand extends BaseCommand {
       stdout: this.context.stdout,
       stderr: this.context.stderr,
       env: {
-        ...(await scriptUtils.makeScriptEnv({ binFolder, project })),
+        ...(await scriptUtils.makeScriptEnv({ binFolder, project, ignoreCorepack: true })),
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })

--- a/yarn/plugin-lint/sources/lint.command.tsx
+++ b/yarn/plugin-lint/sources/lint.command.tsx
@@ -60,7 +60,7 @@ export class LintCommand extends BaseCommand {
       stdout: this.context.stdout,
       stderr: this.context.stderr,
       env: {
-        ...(await scriptUtils.makeScriptEnv({ binFolder, project })),
+        ...(await scriptUtils.makeScriptEnv({ binFolder, project, ignoreCorepack: true })),
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })

--- a/yarn/plugin-renderer/sources/commands/renderer-build.command.ts
+++ b/yarn/plugin-renderer/sources/commands/renderer-build.command.ts
@@ -4,9 +4,11 @@ import { PassThrough }       from 'node:stream'
 
 import { BaseCommand }       from '@yarnpkg/cli'
 import { Configuration }     from '@yarnpkg/core'
+import { Project }           from '@yarnpkg/core'
 import { StreamReport }      from '@yarnpkg/core'
 import { MessageName }       from '@yarnpkg/core'
 import { execUtils }         from '@yarnpkg/core'
+import { scriptUtils }       from '@yarnpkg/core'
 import { xfs }               from '@yarnpkg/fslib'
 import { ppath }             from '@yarnpkg/fslib'
 
@@ -15,6 +17,7 @@ export class RendererBuildCommand extends BaseCommand {
 
   async execute(): Promise<number> {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins)
+    const { project } = await Project.find(configuration, this.context.cwd)
 
     const commandReport = await StreamReport.start(
       {
@@ -50,6 +53,12 @@ export class RendererBuildCommand extends BaseCommand {
             await xfs.writeJsonPromise(ppath.join(this.context.cwd, 'src/package.json'), {
               type: 'module',
             })
+            const binFolder = await xfs.mktempPromise()
+            const env = await scriptUtils.makeScriptEnv({
+              binFolder,
+              project,
+              ignoreCorepack: true,
+            })
 
             await execUtils.pipevp('yarn', ['next', 'build', 'src', '--no-lint'], {
               end: execUtils.EndStrategy.ErrorCode,
@@ -57,6 +66,7 @@ export class RendererBuildCommand extends BaseCommand {
               stdin: this.context.stdin,
               stdout,
               stderr,
+              env,
             })
           } catch (error) {
             report.reportError(

--- a/yarn/plugin-renderer/sources/commands/renderer-dev.command.ts
+++ b/yarn/plugin-renderer/sources/commands/renderer-dev.command.ts
@@ -3,6 +3,7 @@ import type { Tunnel }   from 'localtunnel'
 import { BaseCommand }   from '@yarnpkg/cli'
 import { Configuration } from '@yarnpkg/core'
 import { Project }       from '@yarnpkg/core'
+import { scriptUtils }   from '@yarnpkg/core'
 import { xfs }           from '@yarnpkg/fslib'
 import { ppath }         from '@yarnpkg/fslib'
 import { Option }        from 'clipanion'
@@ -59,7 +60,14 @@ export class RendererDevCommand extends BaseCommand {
       args.push('--experimental-https-cert', ppath.join(project.cwd, '.config/certs/local/dev.crt'))
     }
 
-    spawn('yarn', args, { stdio: 'inherit', cwd: this.context.cwd })
+    const binFolder = await xfs.mktempPromise()
+    const env = await scriptUtils.makeScriptEnv({
+      binFolder,
+      project,
+      ignoreCorepack: true,
+    })
+
+    spawn('yarn', args, { stdio: 'inherit', cwd: this.context.cwd, env })
 
     if (this.tunnel) {
       const workspace = project.getWorkspaceByCwd(this.context.cwd)

--- a/yarn/plugin-service/sources/service-build.command.tsx
+++ b/yarn/plugin-service/sources/service-build.command.tsx
@@ -49,7 +49,7 @@ export class ServiceBuildCommand extends AbstractServiceCommand {
       stdout: this.context.stdout,
       stderr: this.context.stderr,
       env: {
-        ...(await scriptUtils.makeScriptEnv({ binFolder, project })),
+        ...(await scriptUtils.makeScriptEnv({ binFolder, project, ignoreCorepack: true })),
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })

--- a/yarn/plugin-service/sources/service-dev.command.tsx
+++ b/yarn/plugin-service/sources/service-dev.command.tsx
@@ -47,7 +47,7 @@ export class ServiceDevCommand extends AbstractServiceCommand {
       stdout: this.context.stdout,
       stderr: this.context.stderr,
       env: {
-        ...(await scriptUtils.makeScriptEnv({ binFolder, project })),
+        ...(await scriptUtils.makeScriptEnv({ binFolder, project, ignoreCorepack: true })),
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })

--- a/yarn/plugin-test/sources/abstract-test.command.tsx
+++ b/yarn/plugin-test/sources/abstract-test.command.tsx
@@ -87,7 +87,7 @@ export abstract class AbstractTestCommand extends BaseCommand {
 
     const binFolder = await xfs.mktempPromise()
 
-    const env = await scriptUtils.makeScriptEnv({ binFolder, project })
+    const env = await scriptUtils.makeScriptEnv({ binFolder, project, ignoreCorepack: true })
 
     if (!env.NODE_OPTIONS?.includes('--no-warnings')) {
       env.NODE_OPTIONS = `${env.NODE_OPTIONS ?? ''} --no-warnings=DeprecationWarning`

--- a/yarn/plugin-tools/sources/commands/sync/abstract-tools.command.ts
+++ b/yarn/plugin-tools/sources/commands/sync/abstract-tools.command.ts
@@ -47,7 +47,7 @@ export abstract class AbstractToolsCommand extends BaseCommand {
       stdout: this.context.stdout,
       stderr: this.context.stderr,
       env: {
-        ...(await scriptUtils.makeScriptEnv({ binFolder, project })),
+        ...(await scriptUtils.makeScriptEnv({ binFolder, project, ignoreCorepack: true })),
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })

--- a/yarn/plugin-tools/sources/hooks/after-yarn-version-set.hook.ts
+++ b/yarn/plugin-tools/sources/hooks/after-yarn-version-set.hook.ts
@@ -1,17 +1,25 @@
 import type { Configuration }  from '@yarnpkg/core'
 import type { CommandContext } from '@yarnpkg/core'
 
+import { Project }             from '@yarnpkg/core'
 import { execUtils }           from '@yarnpkg/core'
+import { scriptUtils }         from '@yarnpkg/core'
+import { xfs }                 from '@yarnpkg/fslib'
 
 export const afterYarnVersionSet = async (
-  _: Configuration,
+  configuration: Configuration,
   context: CommandContext
 ): Promise<void> => {
+  const { project } = await Project.find(configuration, context.cwd)
+  const binFolder = await xfs.mktempPromise()
+  const env = await scriptUtils.makeScriptEnv({ binFolder, project, ignoreCorepack: true })
+
   await execUtils.pipevp('yarn', ['tools', 'sync'], {
     cwd: context.cwd,
     stdin: context.stdin,
     stdout: context.stdout,
     stderr: context.stderr,
     end: execUtils.EndStrategy.ErrorCode,
+    env,
   })
 }

--- a/yarn/plugin-typescript/sources/typecheck.command.tsx
+++ b/yarn/plugin-typescript/sources/typecheck.command.tsx
@@ -47,7 +47,7 @@ export class TypeCheckCommand extends BaseCommand {
       stdout: this.context.stdout,
       stderr: this.context.stderr,
       env: {
-        ...(await scriptUtils.makeScriptEnv({ binFolder, project })),
+        ...(await scriptUtils.makeScriptEnv({ binFolder, project, ignoreCorepack: true })),
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })

--- a/yarn/plugin-ui/sources/commands/ui-icons-generate.command.tsx
+++ b/yarn/plugin-ui/sources/commands/ui-icons-generate.command.tsx
@@ -55,7 +55,7 @@ export class UiIconsGenerateCommand extends BaseCommand {
       stdout: this.context.stdout,
       stderr: this.context.stderr,
       env: {
-        ...(await scriptUtils.makeScriptEnv({ binFolder, project })),
+        ...(await scriptUtils.makeScriptEnv({ binFolder, project, ignoreCorepack: true })),
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })


### PR DESCRIPTION
## Таска
- Close atls/raijin#606

## Как проверять
### До фикса
1. Контекст: локальный PnP runtime, Node `v24.11.1`, запуск через глобальный `yarn` Corepack shim.
Действие: запустить `yarn check` или смежные proxy-команды (`yarn typecheck`, `yarn lint`, `yarn checks run --changed`).
Ожидаемый результат: До фикса: вложенные proxy re-entry вызовы не должны пытаться идти через `COREPACK_ROOT/dist/yarn.js`; до фикса падали с обращением к `corepack` внутри PnP.

### После фикса
1. Контекст: тот же локальный PnP runtime, Node `v24.11.1`, запуск через глобальный `yarn` Corepack shim.
Действие: выполнить `yarn typecheck`, `yarn lint`, `yarn checks run --changed`, `yarn check`.
Ожидаемый результат: После фикса: все команды завершаются с `exit code 0`, без `Your application tried to access corepack`, `Required package: corepack`, `corepack/package.json` в логах.

2. Контекст: repo wrapper runtime.
Действие: выполнить `./.yarn/bin/yarn check`.
Ожидаемый результат: После фикса: команда завершается с `exit code 0`, CLI-контракт `check/lint/typecheck/checks` сохраняется.

3. Контекст: source-level regression guard для proxy re-entry.
Действие: выполнить `node --test yarn/plugin-checks/sources/proxy-corepack-env.guard.test.js` или общий `yarn check`.
Ожидаемый результат: После фикса: guard падает, если nested `yarn` process call в обязательных plugin groups не использует `scriptUtils.makeScriptEnv` с `ignoreCorepack: true` и не передаёт `env` в child process.

## Пруфы
- `head -n 5 $(which yarn)`
```js
#!/usr/bin/env node
process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT??='1'
require('module').enableCompileCache?.();
require('./lib/corepack.cjs').runMain(['yarn', ...process.argv.slice(2)]);
```

- `node -v`
```text
v24.11.1
```

- проверки через глобальный `yarn` Corepack shim
```text
yarn typecheck              exit code 0
yarn lint                   exit code 0
yarn checks run --changed   exit code 0
yarn check                  exit code 0
```

- контрольный запуск через repo wrapper
```text
./.yarn/bin/yarn check       exit code 0
```

- guard-тест
```text
node --test yarn/plugin-checks/sources/proxy-corepack-env.guard.test.js
exit code 0
```

- проверки после добавления guard
```text
yarn check                  exit code 0
./.yarn/bin/yarn check       exit code 0
```

- поиск corepack-сигнатур в логах проверок
```text
rg -n "Your application tried to access corepack|Required package: corepack|corepack/package.json" <logs>
exit code 1, совпадений нет
```
