### PR TITLE
feat(github): auto-add issues to raijin project

### DIFF
--- a/.github/workflows/project-auto-add-issues.yaml
+++ b/.github/workflows/project-auto-add-issues.yaml
@@ -1,0 +1,28 @@
+name: Project auto-add issues
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+
+jobs:
+  add:
+    name: Add issue to Raijin project
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.ATLANTIS_SUPER_BOT_APP_ID }}
+          private-key: ${{ secrets.ATLANTIS_SUPER_BOT_PRIVATE_KEY }}
+
+      - name: Add issue to project
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: gh project item-add 27 --owner atls --url "$ISSUE_URL"


### PR DESCRIPTION
## Таска
- Close atls/raijin#611

## Как проверять
### Основной сценарий
1. Контекст: GitHub issue создаётся или переносится в `atls/raijin`.
Действие: срабатывает workflow `Project auto-add issues`.
Ожидаемый результат: issue добавляется в GitHub Project `Raijin`.

### Дополнительный сценарий
1. Контекст: workflow-файл лежит в `.github/workflows/project-auto-add-issues.yaml`.
Действие: проверить YAML синтаксис.
Ожидаемый результат: файл валиден и содержит только добавление issue в project без labels/body mutations.

## Пруфы
- `gh project view 27 --owner atls --format json`
```json
{"closed":false,"number":27,"owner":{"login":"atls","type":"Organization"},"public":false,"title":"Raijin","url":"https://github.com/orgs/atls/projects/27"}
```

- `ruby -e 'require "psych"; Psych.load_file(".github/workflows/project-auto-add-issues.yaml"); puts "yaml ok"'`
```text
yaml ok
```
