### PR TITLE
test(yarn-plugin-checks): add corepack shim behavioral e2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![raijin-github-cover](https://user-images.githubusercontent.com/102182195/234980835-78ed0fdb-c692-4b0e-ac95-b46c8cbd17a4.png)
+![raijin-github-cover](https://github.com/user-attachments/assets/ac98b900-ee3c-4ea8-a081-e83a1f5f3282)
 
 # Atlantis Raijin
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,4 +1,4 @@
-![raijin-github-cover](https://user-images.githubusercontent.com/102182195/234980835-78ed0fdb-c692-4b0e-ac95-b46c8cbd17a4.png)
+![raijin-github-cover](https://github.com/user-attachments/assets/ac98b900-ee3c-4ea8-a081-e83a1f5f3282)
 
 # Atlantis Raijin
 

--- a/code/code-icons/src/icons.test.ts
+++ b/code/code-icons/src/icons.test.ts
@@ -1,9 +1,9 @@
-import assert     from 'node:assert/strict'
-import { test }   from 'node:test'
-
 import type { Config } from '@atls/code-runtime/svgr'
 
-import { Icons }  from './icons.js'
+import assert          from 'node:assert/strict'
+import { test }        from 'node:test'
+
+import { Icons }       from './icons.js'
 
 type ReplaceAttrValues = Record<string, string>
 
@@ -79,7 +79,9 @@ test('should pass configured replacements when replacement entry exists', async 
     '#000': 'currentColor',
   }
 
-  const icons = new TestIcons({ ExistingReplacementIcon: replacement }, async ({ replaceAttrValues }) => {
+  const icons = new TestIcons({ ExistingReplacementIcon: replacement }, async ({
+    replaceAttrValues,
+  }) => {
     replaceAttrValuesCalls.push(replaceAttrValues)
 
     return 'export const ExistingReplacementIcon = () => null'

--- a/scripts/raijin/generate-artifacts.mjs
+++ b/scripts/raijin/generate-artifacts.mjs
@@ -79,7 +79,7 @@ const WORKSPACE_GROUP_ORDER = [
 const DETAILED_GROUPS = new Set(WORKSPACE_GROUP_ORDER.filter((group) => group !== 'cli'))
 
 const COVER_IMAGE_URL =
-  'https://user-images.githubusercontent.com/102182195/234980835-78ed0fdb-c692-4b0e-ac95-b46c8cbd17a4.png'
+  'https://github.com/user-attachments/assets/ac98b900-ee3c-4ea8-a081-e83a1f5f3282'
 
 const walkFiles = (dirPath, predicate, output = []) => {
   if (!fs.existsSync(dirPath)) return output

--- a/yarn/plugin-checks/sources/proxy-corepack-env.behavior.test.js
+++ b/yarn/plugin-checks/sources/proxy-corepack-env.behavior.test.js
@@ -13,7 +13,7 @@ import { test } from 'node:test'
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
 
-const runExecFile = (file, args, options = {}) =>
+const runExecFile = async (file, args, options = {}) =>
   new Promise((resolvePromise) => {
     execFile(
       file,
@@ -42,21 +42,29 @@ test('should run checks proxy via Corepack shim without Corepack package resolut
     await rm(shimDir, { recursive: true, force: true })
   })
 
-  const corepackEnableResult = await runExecFile('corepack', ['enable', '--install-directory', shimDir], {
-    cwd: repoRoot,
-    env: {
-      ...process.env,
-      COREPACK_ENABLE_DOWNLOAD_PROMPT: '0',
-    },
-  })
+  const corepackEnableResult = await runExecFile(
+    'corepack',
+    ['enable', '--install-directory', shimDir],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        COREPACK_ENABLE_DOWNLOAD_PROMPT: '0',
+      },
+    }
+  )
 
-  if (corepackEnableResult.error && corepackEnableResult.error.code === 'ENOENT') {
+  if (corepackEnableResult.error?.code === 'ENOENT') {
     t.skip('corepack is not available in environment')
 
     return
   }
 
-  assert.equal(corepackEnableResult.code, 0, corepackEnableResult.stderr || corepackEnableResult.stdout)
+  assert.equal(
+    corepackEnableResult.code,
+    0,
+    corepackEnableResult.stderr || corepackEnableResult.stdout
+  )
 
   const resolvedShimPath = await realpath(yarnShim)
 
@@ -67,6 +75,7 @@ test('should run checks proxy via Corepack shim without Corepack package resolut
     NODE_OPTIONS: '',
     PATH: `${shimDir}${delimiter}${process.env.PATH ?? ''}`,
     COREPACK_ENABLE_DOWNLOAD_PROMPT: '0',
+    COREPACK_ENABLE_PROJECT_SPEC: '0',
   }
 
   delete env.GITHUB_TOKEN

--- a/yarn/plugin-checks/sources/proxy-corepack-env.behavior.test.js
+++ b/yarn/plugin-checks/sources/proxy-corepack-env.behavior.test.js
@@ -36,6 +36,22 @@ const runExecFile = async (file, args, options = {}) =>
     )
   })
 
+const isCorepackUnavailable = ({ code, error, stdout, stderr }) => {
+  if (error?.code === 'ENOENT') {
+    return true
+  }
+
+  if (code === 127) {
+    return true
+  }
+
+  const combinedOutput = `${stdout}\n${stderr}`
+
+  return /command not found:\s*corepack|corepack:\s*not found|'corepack' is not recognized/i.test(
+    combinedOutput
+  )
+}
+
 test('should run checks proxy via Corepack shim without Corepack package resolution errors', async (t) => {
   const shimDir = await mkdtemp(join(tmpdir(), 'raijin-corepack-shim-'))
   const yarnShim = join(shimDir, process.platform === 'win32' ? 'yarn.cmd' : 'yarn')
@@ -56,7 +72,7 @@ test('should run checks proxy via Corepack shim without Corepack package resolut
     }
   )
 
-  if (corepackEnableResult.error?.code === 'ENOENT') {
+  if (isCorepackUnavailable(corepackEnableResult)) {
     t.skip('corepack is not available in environment')
 
     return

--- a/yarn/plugin-checks/sources/proxy-corepack-env.behavior.test.js
+++ b/yarn/plugin-checks/sources/proxy-corepack-env.behavior.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { execFile } from 'node:child_process'
 import { mkdtemp } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { realpath } from 'node:fs/promises'
 import { rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -69,7 +70,14 @@ test('should run checks proxy via Corepack shim without Corepack package resolut
 
   const resolvedShimPath = await realpath(yarnShim)
 
-  assert.match(resolvedShimPath, /corepack[\\/]+dist[\\/]+yarn\.js$/)
+  if (process.platform === 'win32') {
+    const shimSource = await readFile(yarnShim, 'utf8')
+
+    assert.match(shimSource, /corepack/i)
+    assert.match(shimSource, /yarn/i)
+  } else {
+    assert.match(resolvedShimPath, /corepack[\\/]+dist[\\/]+yarn\.js$/)
+  }
 
   const env = {
     ...process.env,

--- a/yarn/plugin-checks/sources/proxy-corepack-env.behavior.test.js
+++ b/yarn/plugin-checks/sources/proxy-corepack-env.behavior.test.js
@@ -19,6 +19,7 @@ const runExecFile = async (file, args, options = {}) =>
       file,
       args,
       {
+        shell: process.platform === 'win32',
         timeout: 60_000,
         maxBuffer: 1024 * 1024 * 16,
         ...options,

--- a/yarn/plugin-checks/sources/proxy-corepack-env.behavior.test.js
+++ b/yarn/plugin-checks/sources/proxy-corepack-env.behavior.test.js
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { mkdtemp } from 'node:fs/promises'
+import { realpath } from 'node:fs/promises'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname } from 'node:path'
+import { delimiter } from 'node:path'
+import { join } from 'node:path'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { test } from 'node:test'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+
+const runExecFile = (file, args, options = {}) =>
+  new Promise((resolvePromise) => {
+    execFile(
+      file,
+      args,
+      {
+        timeout: 60_000,
+        maxBuffer: 1024 * 1024 * 16,
+        ...options,
+      },
+      (error, stdout, stderr) => {
+        resolvePromise({
+          code: error ? error.code : 0,
+          error,
+          stdout: stdout ?? '',
+          stderr: stderr ?? '',
+        })
+      }
+    )
+  })
+
+test('should run checks proxy via Corepack shim without Corepack package resolution errors', async (t) => {
+  const shimDir = await mkdtemp(join(tmpdir(), 'raijin-corepack-shim-'))
+  const yarnShim = join(shimDir, process.platform === 'win32' ? 'yarn.cmd' : 'yarn')
+
+  t.after(async () => {
+    await rm(shimDir, { recursive: true, force: true })
+  })
+
+  const corepackEnableResult = await runExecFile('corepack', ['enable', '--install-directory', shimDir], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: '0',
+    },
+  })
+
+  if (corepackEnableResult.error && corepackEnableResult.error.code === 'ENOENT') {
+    t.skip('corepack is not available in environment')
+
+    return
+  }
+
+  assert.equal(corepackEnableResult.code, 0, corepackEnableResult.stderr || corepackEnableResult.stdout)
+
+  const resolvedShimPath = await realpath(yarnShim)
+
+  assert.match(resolvedShimPath, /corepack[\\/]+dist[\\/]+yarn\.js$/)
+
+  const env = {
+    ...process.env,
+    NODE_OPTIONS: '',
+    PATH: `${shimDir}${delimiter}${process.env.PATH ?? ''}`,
+    COREPACK_ENABLE_DOWNLOAD_PROMPT: '0',
+  }
+
+  delete env.GITHUB_TOKEN
+
+  const checksRunResult = await runExecFile(yarnShim, ['checks', 'lint', '--changed'], {
+    cwd: repoRoot,
+    env,
+  })
+
+  const combinedOutput = `${checksRunResult.stdout}\n${checksRunResult.stderr}`
+
+  assert.equal(checksRunResult.code, 1, combinedOutput)
+  assert.match(combinedOutput, /GITHUB_TOKEN is not defined/)
+  assert.match(combinedOutput, /\.yarn[\\/]releases[\\/]yarn\.mjs/)
+  assert.doesNotMatch(combinedOutput, /Your application tried to access corepack/)
+  assert.doesNotMatch(combinedOutput, /Required package: corepack/)
+  assert.doesNotMatch(combinedOutput, /corepack\/package\.json/)
+})


### PR DESCRIPTION
## Таска
- Close atls/raijin#610

## Как проверять
### Основной сценарий
1. Контекст: запуск через настоящий global Corepack `yarn` shim с nested re-entry в repo runtime.
Действие: `node --test yarn/plugin-checks/sources/proxy-corepack-env.behavior.test.js`
Ожидаемый результат: тест проходит, в выводе нет `Your application tried to access corepack`, `Required package: corepack`, `corepack/package.json`.

### Дополнительный сценарий
1. Контекст: вместе с runtime e2e нужно сохранить source-level guard.
Действие: `node --test yarn/plugin-checks/sources/proxy-corepack-env.guard.test.js yarn/plugin-checks/sources/proxy-corepack-env.behavior.test.js`
Ожидаемый результат: оба теста проходят.

## Пруфы
- `node --test yarn/plugin-checks/sources/proxy-corepack-env.guard.test.js yarn/plugin-checks/sources/proxy-corepack-env.behavior.test.js`
```text
✔ should run checks proxy via Corepack shim without Corepack package resolution errors
✔ should keep yarn proxy re-entry calls isolated from Corepack
ℹ tests 2
ℹ pass 2
ℹ fail 0
```