### PR TITLE
fix(code-runtime): support css extensions in ts-ext-register

### DIFF
--- a/runtime/code-runtime/src/ts-ext-register.ts
+++ b/runtime/code-runtime/src/ts-ext-register.ts
@@ -14,6 +14,10 @@ const mapping = new Map([
   ['.mjs', ['.mjs', '.mts']],
   ['.cjs', ['.cjs', '.cts']],
   ['.jsx', ['.jsx', '.tsx']],
+  [
+    '.css',
+    ['.css.ts', '.css.tsx', '.css.js', '.css.mjs', '.css.mts', '.css.cjs', '.css.cts', '.css'],
+  ],
 ])
 
 export const resolve: ResolveHook = (

--- a/runtime/code-runtime/unit/ts-ext-register.test.ts
+++ b/runtime/code-runtime/unit/ts-ext-register.test.ts
@@ -1,7 +1,5 @@
 import assert            from 'node:assert/strict'
-import { mkdtempSync }   from 'node:fs'
-import { rmSync }        from 'node:fs'
-import { writeFileSync } from 'node:fs'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir }        from 'node:os'
 import { join }          from 'node:path'
 import { test }          from 'node:test'
@@ -9,18 +7,16 @@ import { pathToFileURL } from 'node:url'
 
 import { resolve }       from '../src/ts-ext-register.js'
 
-const createContext = (parentPath: string) => {
-  return {
-    parentURL: pathToFileURL(parentPath).href,
-  } as never
-}
+const createContext = (parentPath: string) => ({
+  parentURL: pathToFileURL(parentPath).href,
+} as never)
 
-test('should resolve css imports to css.ts source', () => {
-  const workspace = mkdtempSync(join(tmpdir(), 'ts-ext-register-'))
+test('should resolve css imports to css.ts source', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'ts-ext-register-'))
   const parentPath = join(workspace, 'entry.ts')
 
   try {
-    writeFileSync(join(workspace, 'global.css.ts'), 'export const style = {}', 'utf-8')
+    await writeFile(join(workspace, 'global.css.ts'), 'export const style = {}', 'utf-8')
 
     const actual = resolve(
       './global.css',
@@ -30,16 +26,16 @@ test('should resolve css imports to css.ts source', () => {
 
     assert.equal(actual.url, './global.css.ts')
   } finally {
-    rmSync(workspace, { recursive: true, force: true })
+    await rm(workspace, { recursive: true, force: true })
   }
 })
 
-test('should resolve css imports to css source if css.ts is absent', () => {
-  const workspace = mkdtempSync(join(tmpdir(), 'ts-ext-register-'))
+test('should resolve css imports to css source if css.ts is absent', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'ts-ext-register-'))
   const parentPath = join(workspace, 'entry.ts')
 
   try {
-    writeFileSync(join(workspace, 'global.css'), 'body {}', 'utf-8')
+    await writeFile(join(workspace, 'global.css'), 'body {}', 'utf-8')
 
     const actual = resolve(
       './global.css',
@@ -49,12 +45,12 @@ test('should resolve css imports to css source if css.ts is absent', () => {
 
     assert.equal(actual.url, './global.css')
   } finally {
-    rmSync(workspace, { recursive: true, force: true })
+    await rm(workspace, { recursive: true, force: true })
   }
 })
 
-test('should keep original specifier if css source is absent', () => {
-  const workspace = mkdtempSync(join(tmpdir(), 'ts-ext-register-'))
+test('should keep original specifier if css source is absent', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'ts-ext-register-'))
   const parentPath = join(workspace, 'entry.ts')
 
   try {
@@ -66,6 +62,6 @@ test('should keep original specifier if css source is absent', () => {
 
     assert.equal(actual.url, './missing.css')
   } finally {
-    rmSync(workspace, { recursive: true, force: true })
+    await rm(workspace, { recursive: true, force: true })
   }
 })

--- a/runtime/code-runtime/unit/ts-ext-register.test.ts
+++ b/runtime/code-runtime/unit/ts-ext-register.test.ts
@@ -1,0 +1,71 @@
+import assert            from 'node:assert/strict'
+import { mkdtempSync }   from 'node:fs'
+import { rmSync }        from 'node:fs'
+import { writeFileSync } from 'node:fs'
+import { tmpdir }        from 'node:os'
+import { join }          from 'node:path'
+import { test }          from 'node:test'
+import { pathToFileURL } from 'node:url'
+
+import { resolve }       from '../src/ts-ext-register.js'
+
+const createContext = (parentPath: string) => {
+  return {
+    parentURL: pathToFileURL(parentPath).href,
+  } as never
+}
+
+test('should resolve css imports to css.ts source', () => {
+  const workspace = mkdtempSync(join(tmpdir(), 'ts-ext-register-'))
+  const parentPath = join(workspace, 'entry.ts')
+
+  try {
+    writeFileSync(join(workspace, 'global.css.ts'), 'export const style = {}', 'utf-8')
+
+    const actual = resolve(
+      './global.css',
+      createContext(parentPath),
+      (specifier) => ({ format: 'module', url: specifier }) as never
+    ) as { url: string }
+
+    assert.equal(actual.url, './global.css.ts')
+  } finally {
+    rmSync(workspace, { recursive: true, force: true })
+  }
+})
+
+test('should resolve css imports to css source if css.ts is absent', () => {
+  const workspace = mkdtempSync(join(tmpdir(), 'ts-ext-register-'))
+  const parentPath = join(workspace, 'entry.ts')
+
+  try {
+    writeFileSync(join(workspace, 'global.css'), 'body {}', 'utf-8')
+
+    const actual = resolve(
+      './global.css',
+      createContext(parentPath),
+      (specifier) => ({ format: 'module', url: specifier }) as never
+    ) as { url: string }
+
+    assert.equal(actual.url, './global.css')
+  } finally {
+    rmSync(workspace, { recursive: true, force: true })
+  }
+})
+
+test('should keep original specifier if css source is absent', () => {
+  const workspace = mkdtempSync(join(tmpdir(), 'ts-ext-register-'))
+  const parentPath = join(workspace, 'entry.ts')
+
+  try {
+    const actual = resolve(
+      './missing.css',
+      createContext(parentPath),
+      (specifier) => ({ format: 'module', url: specifier }) as never
+    ) as { url: string }
+
+    assert.equal(actual.url, './missing.css')
+  } finally {
+    rmSync(workspace, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Таска
Close atls/raijin#443

## Как проверять
### До фикса
- На импорте `*.css` в integration/e2e тестах происходила ошибка резолва модуля из-за неподдерживаемых расширений в `ts-ext-register`.

### После фикса
- Проверить, что `runtime/code-runtime/src/ts-ext-register.ts` резолвит `test.css` как `test.css.ts`, `test.css.tsx`, `test.css.js`, `test.css.mjs`, `test.css.mts`, `test.css.cjs`, `test.css.cts`, или `test.css`.
- Проверить, что для неизвестного расширения поведение не ломается (fallback к базовому `source` остаётся прежним).

## Пруфы
- Добавлены тесты: `runtime/code-runtime/unit/ts-ext-register.test.ts`
- Запущен `yarn check` (выполнение длительное, см. локальный прогон).
