### PR TITLE
fix(github): force npm publish registries in publish workflow

### DIFF
--- a/.github/actions/publish-github-packages/action.yml
+++ b/.github/actions/publish-github-packages/action.yml
@@ -34,6 +34,7 @@ runs:
         yarn npm whoami --publish
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.GITHUB_PACKAGES_TOKEN }}
+        YARN_NPM_REGISTRY_SERVER: https://npm.pkg.github.com
         YARN_NPM_PUBLISH_REGISTRY: https://npm.pkg.github.com
 
     - name: Publish to GitHub Packages
@@ -45,6 +46,7 @@ runs:
         yarn workspaces changed foreach -vt --no-private npm publish --tolerate-republish --access public
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.GITHUB_PACKAGES_TOKEN }}
+        YARN_NPM_REGISTRY_SERVER: https://npm.pkg.github.com
         YARN_NPM_PUBLISH_REGISTRY: https://npm.pkg.github.com
 
     - name: Publish selected workspace to GitHub Packages
@@ -56,4 +58,5 @@ runs:
         yarn workspace ${{ inputs.WORKSPACE }} npm publish --tolerate-republish --access public
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.GITHUB_PACKAGES_TOKEN }}
+        YARN_NPM_REGISTRY_SERVER: https://npm.pkg.github.com
         YARN_NPM_PUBLISH_REGISTRY: https://npm.pkg.github.com

--- a/.github/actions/publish-github-packages/action.yml
+++ b/.github/actions/publish-github-packages/action.yml
@@ -12,12 +12,6 @@ runs:
   using: composite
 
   steps:
-    - name: Set GitHub Packages registries
-      shell: bash
-      run: |
-        echo "YARN_NPM_REGISTRY_SERVER=https://npm.pkg.github.com" >> "$GITHUB_ENV"
-        echo "YARN_NPM_PUBLISH_REGISTRY=https://npm.pkg.github.com" >> "$GITHUB_ENV"
-
     - name: List changed workspaces
       if: ${{ inputs.WORKSPACE == '' }}
       shell: bash

--- a/.github/actions/publish-github-packages/action.yml
+++ b/.github/actions/publish-github-packages/action.yml
@@ -12,6 +12,12 @@ runs:
   using: composite
 
   steps:
+    - name: Set GitHub Packages registries
+      shell: bash
+      run: |
+        echo "YARN_NPM_REGISTRY_SERVER=https://npm.pkg.github.com" >> "$GITHUB_ENV"
+        echo "YARN_NPM_PUBLISH_REGISTRY=https://npm.pkg.github.com" >> "$GITHUB_ENV"
+
     - name: List changed workspaces
       if: ${{ inputs.WORKSPACE == '' }}
       shell: bash
@@ -34,8 +40,6 @@ runs:
         yarn npm whoami --publish
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.GITHUB_PACKAGES_TOKEN }}
-        YARN_NPM_REGISTRY_SERVER: https://npm.pkg.github.com
-        YARN_NPM_PUBLISH_REGISTRY: https://npm.pkg.github.com
 
     - name: Publish to GitHub Packages
       if: ${{ inputs.WORKSPACE == '' }}
@@ -46,8 +50,6 @@ runs:
         yarn workspaces changed foreach -vt --no-private npm publish --tolerate-republish --access public
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.GITHUB_PACKAGES_TOKEN }}
-        YARN_NPM_REGISTRY_SERVER: https://npm.pkg.github.com
-        YARN_NPM_PUBLISH_REGISTRY: https://npm.pkg.github.com
 
     - name: Publish selected workspace to GitHub Packages
       if: ${{ inputs.WORKSPACE != '' }}
@@ -58,5 +60,3 @@ runs:
         yarn workspace ${{ inputs.WORKSPACE }} npm publish --tolerate-republish --access public
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.GITHUB_PACKAGES_TOKEN }}
-        YARN_NPM_REGISTRY_SERVER: https://npm.pkg.github.com
-        YARN_NPM_PUBLISH_REGISTRY: https://npm.pkg.github.com

--- a/.github/actions/publish-npm/action.yml
+++ b/.github/actions/publish-npm/action.yml
@@ -33,6 +33,7 @@ runs:
         yarn npm whoami --publish
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}
+        YARN_NPM_REGISTRY_SERVER: https://registry.npmjs.org
         YARN_NPM_PUBLISH_REGISTRY: https://registry.npmjs.org
 
     - name: Npm Publish
@@ -44,6 +45,7 @@ runs:
         yarn workspaces changed foreach -vt --no-private npm publish --tolerate-republish --access public
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}
+        YARN_NPM_REGISTRY_SERVER: https://registry.npmjs.org
         YARN_NPM_PUBLISH_REGISTRY: https://registry.npmjs.org
 
     - name: Npm Publish selected workspace
@@ -55,4 +57,5 @@ runs:
         yarn workspace ${{ inputs.WORKSPACE }} npm publish --tolerate-republish --access public
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}
+        YARN_NPM_REGISTRY_SERVER: https://registry.npmjs.org
         YARN_NPM_PUBLISH_REGISTRY: https://registry.npmjs.org

--- a/.github/actions/publish-npm/action.yml
+++ b/.github/actions/publish-npm/action.yml
@@ -11,6 +11,12 @@ runs:
   using: composite
 
   steps:
+    - name: Set NPM registries
+      shell: bash
+      run: |
+        echo "YARN_NPM_REGISTRY_SERVER=https://registry.npmjs.org" >> "$GITHUB_ENV"
+        echo "YARN_NPM_PUBLISH_REGISTRY=https://registry.npmjs.org" >> "$GITHUB_ENV"
+
     - name: List changed workspaces
       if: ${{ inputs.WORKSPACE == '' }}
       shell: bash
@@ -33,8 +39,6 @@ runs:
         yarn npm whoami --publish
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}
-        YARN_NPM_REGISTRY_SERVER: https://registry.npmjs.org
-        YARN_NPM_PUBLISH_REGISTRY: https://registry.npmjs.org
 
     - name: Npm Publish
       if: ${{ inputs.WORKSPACE == '' }}
@@ -45,8 +49,6 @@ runs:
         yarn workspaces changed foreach -vt --no-private npm publish --tolerate-republish --access public
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}
-        YARN_NPM_REGISTRY_SERVER: https://registry.npmjs.org
-        YARN_NPM_PUBLISH_REGISTRY: https://registry.npmjs.org
 
     - name: Npm Publish selected workspace
       if: ${{ inputs.WORKSPACE != '' }}
@@ -57,5 +59,3 @@ runs:
         yarn workspace ${{ inputs.WORKSPACE }} npm publish --tolerate-republish --access public
       env:
         YARN_NPM_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}
-        YARN_NPM_REGISTRY_SERVER: https://registry.npmjs.org
-        YARN_NPM_PUBLISH_REGISTRY: https://registry.npmjs.org

--- a/.github/actions/publish-npm/action.yml
+++ b/.github/actions/publish-npm/action.yml
@@ -11,12 +11,6 @@ runs:
   using: composite
 
   steps:
-    - name: Set NPM registries
-      shell: bash
-      run: |
-        echo "YARN_NPM_REGISTRY_SERVER=https://registry.npmjs.org" >> "$GITHUB_ENV"
-        echo "YARN_NPM_PUBLISH_REGISTRY=https://registry.npmjs.org" >> "$GITHUB_ENV"
-
     - name: List changed workspaces
       if: ${{ inputs.WORKSPACE == '' }}
       shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -91,6 +91,9 @@ jobs:
         with:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           WORKSPACE: ${{ inputs.workspace || '' }}
+        env:
+          YARN_NPM_REGISTRY_SERVER: https://registry.npmjs.org
+          YARN_NPM_PUBLISH_REGISTRY: https://registry.npmjs.org
 
       - name: Publish to GitHub Packages
         if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true) }}
@@ -99,6 +102,9 @@ jobs:
         with:
           GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           WORKSPACE: ${{ inputs.workspace || '' }}
+        env:
+          YARN_NPM_REGISTRY_SERVER: https://npm.pkg.github.com
+          YARN_NPM_PUBLISH_REGISTRY: https://npm.pkg.github.com
 
       - name: Bundle yarn
         if: ${{ !cancelled() && github.event.pull_request.merged == true }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,6 +64,7 @@ jobs:
           yarn npm whoami --publish
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          YARN_NPM_REGISTRY_SERVER: https://registry.npmjs.org
           YARN_NPM_PUBLISH_REGISTRY: https://registry.npmjs.org
 
       - name: Verify GitHub Packages auth
@@ -74,6 +75,7 @@ jobs:
           yarn npm whoami --publish
         env:
           YARN_NPM_AUTH_TOKEN: ${{ github.token }}
+          YARN_NPM_REGISTRY_SERVER: https://npm.pkg.github.com
           YARN_NPM_PUBLISH_REGISTRY: https://npm.pkg.github.com
 
       - name: Changelog


### PR DESCRIPTION
## Таска
- Close atls/raijin#588

## Как проверять
### До фикса
1. Контекст: post-merge workflow `Publish` в `master`.
Действие: открыть job `Publish to NPM`.
Ожидаемый результат: `yarn workspaces changed foreach ... npm publish` уходит в `https://registry.yarnpkg.com/@atls%2f...` и падает с `YN0035 404 Not Found`.

### После фикса
1. Контекст: workflow `Publish`, шаг `Publish to NPM`.
Действие: запустить publish (merge path или `workflow_dispatch`) и проверить URL запросов publish.
Ожидаемый результат: publish-запросы идут в `https://registry.npmjs.org`, без обращений к `registry.yarnpkg.com`.

2. Контекст: workflow `Publish`, шаг `Publish to GitHub Packages`.
Действие: запустить publish и проверить URL запросов publish.
Ожидаемый результат: publish-запросы идут в `https://npm.pkg.github.com`.

3. Контекст: republish-сценарий.
Действие: запустить publish на уже существующей версии пакета.
Ожидаемый результат: `--tolerate-republish` не валит pipeline на уже опубликованной версии.

## Пруфы
- Изменения в workflow/env:
  - `.github/workflows/publish.yaml` — `env` на шагах `uses: ./.github/actions/publish-npm` и `uses: ./.github/actions/publish-github-packages`
  - `.github/actions/publish-npm/action.yml`
  - `.github/actions/publish-github-packages/action.yml`

- Локальная проверка резолва registry при выставленных env:
```bash
source .env && \
YARN_NPM_PUBLISH_REGISTRY=https://registry.npmjs.org \
YARN_NPM_REGISTRY_SERVER=https://registry.npmjs.org \
yarn config get npmPublishRegistry
# https://registry.npmjs.org

source .env && \
YARN_NPM_PUBLISH_REGISTRY=https://registry.npmjs.org \
YARN_NPM_REGISTRY_SERVER=https://registry.npmjs.org \
yarn config get npmRegistryServer
# https://registry.npmjs.org
```
