### PR TITLE
fix(github): run checks on pull request merge ref

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -42,6 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
 
       - name: Setup Node


### PR DESCRIPTION
## Таска
- Close atls/raijin#587

## Как проверять
### До фикса
1. Контекст: CI workflow `Checks` на событии `pull_request`.
Действие: checkout выполняется без явного `ref`, поведение не зафиксировано явно в workflow.
Ожидаемый результат: в workflow явно указан merge-ref PR для валидации результата слияния.

### После фикса
1. Контекст: `.github/workflows/checks.yaml`, jobs `checks` и `raijin`.
Действие: в `actions/checkout@v6` добавлен `ref: refs/pull/${{ github.event.pull_request.number }}/merge`.
Ожидаемый результат: оба jobs гарантированно проверяют merge result pull request.

## Пруфы
- `yarn check` (локально): passed (exit code 0)
- Diff:
```diff
+ ref: refs/pull/${{ github.event.pull_request.number }}/merge
```
