### PR TITLE
fix(code-schematics): preserve project-specific gitignore entries

### DIFF
--- a/code/code-schematics/src/schematic/project/project.factory.ts
+++ b/code/code-schematics/src/schematic/project/project.factory.ts
@@ -1,4 +1,6 @@
 import type { Rule }                     from '@angular-devkit/schematics'
+import type { SchematicContext }         from '@angular-devkit/schematics'
+import type { Tree }                     from '@angular-devkit/schematics'
 
 import { MergeStrategy }                 from '@angular-devkit/schematics'
 import { chain }                         from '@angular-devkit/schematics'
@@ -7,10 +9,57 @@ import { mergeWith }                     from '@angular-devkit/schematics'
 import { updateTsConfigRule }            from '../rules/index.js'
 import { generateCommonSource }          from '../sources/index.js'
 import { generateProjectSpecificSource } from '../sources/index.js'
+import { mergeGitIgnoreContent }         from '../utils/index.js'
 
-export const main = (options: Record<string, string>): Rule =>
-  chain([
+const GITIGNORE_PATH = '.gitignore'
+
+const captureGitIgnoreContentRule = (state: { content?: string }): Rule =>
+  (host: Tree): Tree => {
+    const gitIgnoreBuffer = host.read(GITIGNORE_PATH)
+
+    if (!gitIgnoreBuffer) {
+      return host
+    }
+
+    state.content = gitIgnoreBuffer.toString('utf-8')
+
+    return host
+  }
+
+const mergeGitIgnoreContentRule = (state: { content?: string }): Rule =>
+  (host: Tree, context: SchematicContext): Tree => {
+    if (state.content === undefined) {
+      return host
+    }
+
+    const gitIgnoreBuffer = host.read(GITIGNORE_PATH)
+
+    if (!gitIgnoreBuffer) {
+      return host
+    }
+
+    const templateContent = gitIgnoreBuffer.toString('utf-8')
+    const mergedContent = mergeGitIgnoreContent({
+      existingContent: state.content,
+      templateContent,
+    })
+
+    if (mergedContent !== templateContent) {
+      context.logger.info('Merging template .gitignore with project-specific entries')
+      host.overwrite(GITIGNORE_PATH, mergedContent)
+    }
+
+    return host
+  }
+
+export const main = (options: Record<string, string>): Rule => {
+  const state: { content?: string } = {}
+
+  return chain([
+    captureGitIgnoreContentRule(state),
     updateTsConfigRule,
     mergeWith(generateCommonSource(options), MergeStrategy.Overwrite),
     mergeWith(generateProjectSpecificSource(options), MergeStrategy.Overwrite),
+    mergeGitIgnoreContentRule(state),
   ])
+}

--- a/code/code-schematics/src/schematic/utils/index.ts
+++ b/code/code-schematics/src/schematic/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './gitignore.utils.js'
+export * from './merge-gitignore-content.utils.js'
 export * from './tsconfig.utils.js'
 export * from './json.utils.js'
 export * from './yaml.utils.js'

--- a/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.test.ts
+++ b/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.test.ts
@@ -1,0 +1,45 @@
+import assert                    from 'node:assert/strict'
+import { test }                  from 'node:test'
+
+import { mergeGitIgnoreContent } from './merge-gitignore-content.utils.js'
+
+test('should preserve project-specific entries while keeping template section deterministic', () => {
+  const templateContent = ['node_modules', '.yarn/install-state.gz', 'dist/'].join('\n')
+  const existingContent = ['node_modules', '.idea/', '.yarn/install-state.gz', 'coverage/'].join(
+    '\n'
+  )
+
+  const actual = mergeGitIgnoreContent({
+    existingContent,
+    templateContent,
+  })
+
+  assert.equal(
+    actual,
+    ['node_modules', '.yarn/install-state.gz', 'dist/', '', '.idea/', 'coverage/'].join('\n')
+  )
+})
+
+test('should be idempotent for already merged gitignore content', () => {
+  const templateContent = ['node_modules', '.yarn/install-state.gz', 'dist/'].join('\n')
+  const mergedContent = ['node_modules', '.yarn/install-state.gz', 'dist/', '', '.idea/'].join('\n')
+
+  const actual = mergeGitIgnoreContent({
+    existingContent: mergedContent,
+    templateContent,
+  })
+
+  assert.equal(actual, mergedContent)
+})
+
+test('should not duplicate template entries from project content', () => {
+  const templateContent = ['node_modules', '.yarn/install-state.gz', 'dist/'].join('\n')
+  const existingContent = ['node_modules', '.yarn/install-state.gz', 'dist/'].join('\n')
+
+  const actual = mergeGitIgnoreContent({
+    existingContent,
+    templateContent,
+  })
+
+  assert.equal(actual, templateContent)
+})

--- a/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.test.ts
+++ b/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.test.ts
@@ -142,8 +142,8 @@ test('should preserve project-specific lines added outside managed block', () =>
       'dist/',
       '',
       '# raijin:begin project-specific gitignore',
-      '.idea/',
       '.custom-above-block/',
+      '.idea/',
       '.custom-below-block/',
       '# raijin:end project-specific gitignore',
     ].join('\n')
@@ -176,8 +176,41 @@ test('should preserve project-specific lines in template area before managed blo
       'dist/',
       '',
       '# raijin:begin project-specific gitignore',
-      '.idea/',
       '.custom-top-line/',
+      '.idea/',
+      '# raijin:end project-specific gitignore',
+    ].join('\n')
+  )
+})
+
+test('should preserve project-specific negation order around managed block', () => {
+  const templateContent = ['node_modules', '.yarn/install-state.gz', 'dist/'].join('\n')
+  const existingContent = [
+    'node_modules',
+    '.yarn/install-state.gz',
+    'dist/',
+    '',
+    '*.log',
+    '# raijin:begin project-specific gitignore',
+    '!important.log',
+    '# raijin:end project-specific gitignore',
+  ].join('\n')
+
+  const actual = mergeGitIgnoreContent({
+    existingContent,
+    templateContent,
+  })
+
+  assert.equal(
+    actual,
+    [
+      'node_modules',
+      '.yarn/install-state.gz',
+      'dist/',
+      '',
+      '# raijin:begin project-specific gitignore',
+      '*.log',
+      '!important.log',
       '# raijin:end project-specific gitignore',
     ].join('\n')
   )

--- a/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.test.ts
+++ b/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.test.ts
@@ -113,3 +113,38 @@ test('should normalize CRLF input before comparison', () => {
     ].join('\n')
   )
 })
+
+test('should preserve project-specific lines added outside managed block', () => {
+  const templateContent = ['node_modules', '.yarn/install-state.gz', 'dist/'].join('\n')
+  const existingContent = [
+    'node_modules',
+    '.yarn/install-state.gz',
+    'dist/',
+    '',
+    '.custom-above-block/',
+    '# raijin:begin project-specific gitignore',
+    '.idea/',
+    '# raijin:end project-specific gitignore',
+    '.custom-below-block/',
+  ].join('\n')
+
+  const actual = mergeGitIgnoreContent({
+    existingContent,
+    templateContent,
+  })
+
+  assert.equal(
+    actual,
+    [
+      'node_modules',
+      '.yarn/install-state.gz',
+      'dist/',
+      '',
+      '# raijin:begin project-specific gitignore',
+      '.idea/',
+      '.custom-above-block/',
+      '.custom-below-block/',
+      '# raijin:end project-specific gitignore',
+    ].join('\n')
+  )
+})

--- a/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.test.ts
+++ b/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.test.ts
@@ -61,6 +61,17 @@ test('should not duplicate template entries from project content', () => {
   assert.equal(actual, templateContent)
 })
 
+test('should not create project-specific block for blank existing content', () => {
+  const templateContent = ['node_modules', '.yarn/install-state.gz', 'dist/'].join('\n')
+
+  const actual = mergeGitIgnoreContent({
+    existingContent: '\n',
+    templateContent,
+  })
+
+  assert.equal(actual, templateContent)
+})
+
 test('should not keep removed template rules when managed block exists', () => {
   const templateContent = ['node_modules', '.yarn/install-state.gz'].join('\n')
   const existingContent = [

--- a/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.test.ts
+++ b/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.test.ts
@@ -16,13 +16,30 @@ test('should preserve project-specific entries while keeping template section de
 
   assert.equal(
     actual,
-    ['node_modules', '.yarn/install-state.gz', 'dist/', '', '.idea/', 'coverage/'].join('\n')
+    [
+      'node_modules',
+      '.yarn/install-state.gz',
+      'dist/',
+      '',
+      '# raijin:begin project-specific gitignore',
+      '.idea/',
+      'coverage/',
+      '# raijin:end project-specific gitignore',
+    ].join('\n')
   )
 })
 
 test('should be idempotent for already merged gitignore content', () => {
   const templateContent = ['node_modules', '.yarn/install-state.gz', 'dist/'].join('\n')
-  const mergedContent = ['node_modules', '.yarn/install-state.gz', 'dist/', '', '.idea/'].join('\n')
+  const mergedContent = [
+    'node_modules',
+    '.yarn/install-state.gz',
+    'dist/',
+    '',
+    '# raijin:begin project-specific gitignore',
+    '.idea/',
+    '# raijin:end project-specific gitignore',
+  ].join('\n')
 
   const actual = mergeGitIgnoreContent({
     existingContent: mergedContent,
@@ -42,4 +59,57 @@ test('should not duplicate template entries from project content', () => {
   })
 
   assert.equal(actual, templateContent)
+})
+
+test('should not keep removed template rules when managed block exists', () => {
+  const templateContent = ['node_modules', '.yarn/install-state.gz'].join('\n')
+  const existingContent = [
+    'node_modules',
+    '.yarn/install-state.gz',
+    'dist/',
+    '',
+    '# raijin:begin project-specific gitignore',
+    '.idea/',
+    '# raijin:end project-specific gitignore',
+  ].join('\n')
+
+  const actual = mergeGitIgnoreContent({
+    existingContent,
+    templateContent,
+  })
+
+  assert.equal(
+    actual,
+    [
+      'node_modules',
+      '.yarn/install-state.gz',
+      '',
+      '# raijin:begin project-specific gitignore',
+      '.idea/',
+      '# raijin:end project-specific gitignore',
+    ].join('\n')
+  )
+})
+
+test('should normalize CRLF input before comparison', () => {
+  const templateContent = ['node_modules', '.yarn/install-state.gz', 'dist/'].join('\n')
+  const existingContent = ['node_modules', '.yarn/install-state.gz', 'dist/', '.idea/'].join('\r\n')
+
+  const actual = mergeGitIgnoreContent({
+    existingContent,
+    templateContent,
+  })
+
+  assert.equal(
+    actual,
+    [
+      'node_modules',
+      '.yarn/install-state.gz',
+      'dist/',
+      '',
+      '# raijin:begin project-specific gitignore',
+      '.idea/',
+      '# raijin:end project-specific gitignore',
+    ].join('\n')
+  )
 })

--- a/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.test.ts
+++ b/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.test.ts
@@ -85,6 +85,7 @@ test('should not keep removed template rules when managed block exists', () => {
       '.yarn/install-state.gz',
       '',
       '# raijin:begin project-specific gitignore',
+      'dist/',
       '.idea/',
       '# raijin:end project-specific gitignore',
     ].join('\n')
@@ -144,6 +145,39 @@ test('should preserve project-specific lines added outside managed block', () =>
       '.idea/',
       '.custom-above-block/',
       '.custom-below-block/',
+      '# raijin:end project-specific gitignore',
+    ].join('\n')
+  )
+})
+
+test('should preserve project-specific lines in template area before managed block', () => {
+  const templateContent = ['node_modules', '.yarn/install-state.gz', 'dist/'].join('\n')
+  const existingContent = [
+    '.custom-top-line/',
+    'node_modules',
+    '.yarn/install-state.gz',
+    'dist/',
+    '',
+    '# raijin:begin project-specific gitignore',
+    '.idea/',
+    '# raijin:end project-specific gitignore',
+  ].join('\n')
+
+  const actual = mergeGitIgnoreContent({
+    existingContent,
+    templateContent,
+  })
+
+  assert.equal(
+    actual,
+    [
+      'node_modules',
+      '.yarn/install-state.gz',
+      'dist/',
+      '',
+      '# raijin:begin project-specific gitignore',
+      '.idea/',
+      '.custom-top-line/',
       '# raijin:end project-specific gitignore',
     ].join('\n')
   )

--- a/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
+++ b/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
@@ -20,20 +20,89 @@ const trimTrailingEmptyLines = (lines: Array<string>): Array<string> => {
   return normalizedLines
 }
 
+const isProjectSpecificLine = (line: string, templateLineSet: Set<string>): boolean =>
+  line !== '' &&
+  !templateLineSet.has(line) &&
+  line !== PROJECT_SPECIFIC_START_MARKER &&
+  line !== PROJECT_SPECIFIC_END_MARKER
+
+const getTemplateBoundaryIndices = (
+  lines: Array<string>,
+  templateLines: Array<string>
+): { firstMatchedIndex: number; lastMatchedIndex: number } => {
+  let templateIndex = 0
+  let firstMatchedIndex = -1
+  let lastMatchedIndex = -1
+
+  for (
+    let lineIndex = 0;
+    lineIndex < lines.length && templateIndex < templateLines.length;
+    lineIndex += 1
+  ) {
+    if (lines[lineIndex] === templateLines[templateIndex]) {
+      if (firstMatchedIndex === -1) {
+        firstMatchedIndex = lineIndex
+      }
+
+      lastMatchedIndex = lineIndex
+      templateIndex += 1
+    }
+  }
+
+  return {
+    firstMatchedIndex,
+    lastMatchedIndex,
+  }
+}
+
 const getProjectSpecificLines = (
   existingLines: Array<string>,
+  templateLines: Array<string>,
   templateLineSet: Set<string>
 ): Array<string> => {
   const startIndex = existingLines.indexOf(PROJECT_SPECIFIC_START_MARKER)
   const endIndex = existingLines.indexOf(PROJECT_SPECIFIC_END_MARKER)
 
   if (startIndex !== -1 && endIndex > startIndex) {
-    return existingLines.filter(
-      (line) =>
-        line !== '' &&
-        !templateLineSet.has(line) &&
-        line !== PROJECT_SPECIFIC_START_MARKER &&
-        line !== PROJECT_SPECIFIC_END_MARKER
+    const linesBeforeBlock = existingLines.slice(0, startIndex)
+    const linesAfterBlock = existingLines.slice(endIndex + 1)
+    const managedProjectSpecificLines = existingLines
+      .slice(startIndex + 1, endIndex)
+      .filter((line) => isProjectSpecificLine(line, templateLineSet))
+    const { firstMatchedIndex, lastMatchedIndex } = getTemplateBoundaryIndices(
+      linesBeforeBlock,
+      templateLines
+    )
+    const blockSeparatorIndex = linesBeforeBlock.lastIndexOf('')
+    const removedTemplateTailLines: Array<string> = []
+    const outsideBlockProjectSpecificLines: Array<string> = []
+
+    linesBeforeBlock.forEach((line, lineIndex) => {
+      if (!isProjectSpecificLine(line, templateLineSet)) {
+        return
+      }
+
+      const isAfterSeparator = blockSeparatorIndex !== -1 && lineIndex > blockSeparatorIndex
+
+      if (!isAfterSeparator && firstMatchedIndex !== -1 && lineIndex > lastMatchedIndex) {
+        removedTemplateTailLines.push(line)
+
+        return
+      }
+
+      outsideBlockProjectSpecificLines.push(line)
+    })
+
+    outsideBlockProjectSpecificLines.push(
+      ...linesAfterBlock.filter((line) => isProjectSpecificLine(line, templateLineSet))
+    )
+
+    return Array.from(
+      new Set([
+        ...removedTemplateTailLines,
+        ...managedProjectSpecificLines,
+        ...outsideBlockProjectSpecificLines,
+      ])
     )
   }
 
@@ -48,7 +117,11 @@ export const mergeGitIgnoreContent = ({
   const templateLineSet = new Set(templateLines)
   const existingLines = getNormalizedLines(existingContent)
 
-  const projectSpecificLines = getProjectSpecificLines(existingLines, templateLineSet)
+  const projectSpecificLines = getProjectSpecificLines(
+    existingLines,
+    templateLines,
+    templateLineSet
+  )
 
   if (projectSpecificLines.length === 0) {
     return trimTrailingEmptyLines(templateLines).join('\n')

--- a/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
+++ b/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
@@ -28,22 +28,12 @@ const getProjectSpecificLines = (
   const endIndex = existingLines.indexOf(PROJECT_SPECIFIC_END_MARKER)
 
   if (startIndex !== -1 && endIndex > startIndex) {
-    const linesBeforeBlock = existingLines.slice(0, startIndex)
-    const linesAfterBlock = existingLines.slice(endIndex + 1)
-    const outsideBlockProjectSpecificLines = [...linesBeforeBlock, ...linesAfterBlock].filter(
+    return existingLines.filter(
       (line) =>
         line !== '' &&
         !templateLineSet.has(line) &&
         line !== PROJECT_SPECIFIC_START_MARKER &&
         line !== PROJECT_SPECIFIC_END_MARKER
-    )
-
-    const managedProjectSpecificLines = trimTrailingEmptyLines(
-      existingLines.slice(startIndex + 1, endIndex)
-    )
-
-    return Array.from(
-      new Set([...managedProjectSpecificLines, ...outsideBlockProjectSpecificLines])
     )
   }
 

--- a/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
+++ b/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
@@ -1,0 +1,39 @@
+type MergeGitIgnoreContentOptions = {
+  existingContent: string
+  templateContent: string
+}
+
+const trimTrailingEmptyLines = (lines: Array<string>): Array<string> => {
+  const normalizedLines = [...lines]
+
+  while (normalizedLines.length > 0 && normalizedLines[normalizedLines.length - 1] === '') {
+    normalizedLines.pop()
+  }
+
+  return normalizedLines
+}
+
+export const mergeGitIgnoreContent = ({
+  existingContent,
+  templateContent,
+}: MergeGitIgnoreContentOptions): string => {
+  const templateLines = templateContent.split('\n')
+  const templateLineSet = new Set(templateLines)
+  const existingLines = existingContent.split('\n')
+
+  const projectSpecificLines = existingLines.filter((line) => !templateLineSet.has(line))
+
+  if (projectSpecificLines.length === 0) {
+    return templateContent
+  }
+
+  const mergedLines = trimTrailingEmptyLines(templateLines)
+
+  if (mergedLines.length > 0) {
+    mergedLines.push('')
+  }
+
+  mergedLines.push(...projectSpecificLines)
+
+  return mergedLines.join('\n')
+}

--- a/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
+++ b/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
@@ -28,7 +28,25 @@ const getProjectSpecificLines = (
   const endIndex = existingLines.indexOf(PROJECT_SPECIFIC_END_MARKER)
 
   if (startIndex !== -1 && endIndex > startIndex) {
-    return trimTrailingEmptyLines(existingLines.slice(startIndex + 1, endIndex))
+    const linesBeforeBlock = existingLines.slice(0, startIndex)
+    const linesAfterBlock = existingLines.slice(endIndex + 1)
+
+    const blockSeparatorIndex = linesBeforeBlock.lastIndexOf('')
+
+    const userLinesBeforeBlock =
+      blockSeparatorIndex >= 0 ? linesBeforeBlock.slice(blockSeparatorIndex + 1) : []
+
+    const outsideBlockProjectSpecificLines = [...userLinesBeforeBlock, ...linesAfterBlock].filter(
+      (line) => line !== '' && !templateLineSet.has(line)
+    )
+
+    const managedProjectSpecificLines = trimTrailingEmptyLines(
+      existingLines.slice(startIndex + 1, endIndex)
+    )
+
+    return Array.from(
+      new Set([...managedProjectSpecificLines, ...outsideBlockProjectSpecificLines])
+    )
   }
 
   return existingLines.filter((line) => !templateLineSet.has(line))

--- a/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
+++ b/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
@@ -30,14 +30,12 @@ const getProjectSpecificLines = (
   if (startIndex !== -1 && endIndex > startIndex) {
     const linesBeforeBlock = existingLines.slice(0, startIndex)
     const linesAfterBlock = existingLines.slice(endIndex + 1)
-
-    const blockSeparatorIndex = linesBeforeBlock.lastIndexOf('')
-
-    const userLinesBeforeBlock =
-      blockSeparatorIndex >= 0 ? linesBeforeBlock.slice(blockSeparatorIndex + 1) : []
-
-    const outsideBlockProjectSpecificLines = [...userLinesBeforeBlock, ...linesAfterBlock].filter(
-      (line) => line !== '' && !templateLineSet.has(line)
+    const outsideBlockProjectSpecificLines = [...linesBeforeBlock, ...linesAfterBlock].filter(
+      (line) =>
+        line !== '' &&
+        !templateLineSet.has(line) &&
+        line !== PROJECT_SPECIFIC_START_MARKER &&
+        line !== PROJECT_SPECIFIC_END_MARKER
     )
 
     const managedProjectSpecificLines = trimTrailingEmptyLines(

--- a/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
+++ b/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
@@ -26,83 +26,18 @@ const isProjectSpecificLine = (line: string, templateLineSet: Set<string>): bool
   line !== PROJECT_SPECIFIC_START_MARKER &&
   line !== PROJECT_SPECIFIC_END_MARKER
 
-const getTemplateBoundaryIndices = (
-  lines: Array<string>,
-  templateLines: Array<string>
-): { firstMatchedIndex: number; lastMatchedIndex: number } => {
-  let templateIndex = 0
-  let firstMatchedIndex = -1
-  let lastMatchedIndex = -1
-
-  for (
-    let lineIndex = 0;
-    lineIndex < lines.length && templateIndex < templateLines.length;
-    lineIndex += 1
-  ) {
-    if (lines[lineIndex] === templateLines[templateIndex]) {
-      if (firstMatchedIndex === -1) {
-        firstMatchedIndex = lineIndex
-      }
-
-      lastMatchedIndex = lineIndex
-      templateIndex += 1
-    }
-  }
-
-  return {
-    firstMatchedIndex,
-    lastMatchedIndex,
-  }
-}
-
 const getProjectSpecificLines = (
   existingLines: Array<string>,
-  templateLines: Array<string>,
   templateLineSet: Set<string>
 ): Array<string> => {
   const startIndex = existingLines.indexOf(PROJECT_SPECIFIC_START_MARKER)
   const endIndex = existingLines.indexOf(PROJECT_SPECIFIC_END_MARKER)
 
   if (startIndex !== -1 && endIndex > startIndex) {
-    const linesBeforeBlock = existingLines.slice(0, startIndex)
-    const linesAfterBlock = existingLines.slice(endIndex + 1)
-    const managedProjectSpecificLines = existingLines
-      .slice(startIndex + 1, endIndex)
-      .filter((line) => isProjectSpecificLine(line, templateLineSet))
-    const { firstMatchedIndex, lastMatchedIndex } = getTemplateBoundaryIndices(
-      linesBeforeBlock,
-      templateLines
-    )
-    const blockSeparatorIndex = linesBeforeBlock.lastIndexOf('')
-    const removedTemplateTailLines: Array<string> = []
-    const outsideBlockProjectSpecificLines: Array<string> = []
-
-    linesBeforeBlock.forEach((line, lineIndex) => {
-      if (!isProjectSpecificLine(line, templateLineSet)) {
-        return
-      }
-
-      const isAfterSeparator = blockSeparatorIndex !== -1 && lineIndex > blockSeparatorIndex
-
-      if (!isAfterSeparator && firstMatchedIndex !== -1 && lineIndex > lastMatchedIndex) {
-        removedTemplateTailLines.push(line)
-
-        return
-      }
-
-      outsideBlockProjectSpecificLines.push(line)
-    })
-
-    outsideBlockProjectSpecificLines.push(
-      ...linesAfterBlock.filter((line) => isProjectSpecificLine(line, templateLineSet))
-    )
-
     return Array.from(
-      new Set([
-        ...removedTemplateTailLines,
-        ...managedProjectSpecificLines,
-        ...outsideBlockProjectSpecificLines,
-      ])
+      new Set(
+        existingLines.filter((line) => isProjectSpecificLine(line, templateLineSet))
+      )
     )
   }
 
@@ -117,11 +52,7 @@ export const mergeGitIgnoreContent = ({
   const templateLineSet = new Set(templateLines)
   const existingLines = getNormalizedLines(existingContent)
 
-  const projectSpecificLines = getProjectSpecificLines(
-    existingLines,
-    templateLines,
-    templateLineSet
-  )
+  const projectSpecificLines = getProjectSpecificLines(existingLines, templateLineSet)
 
   if (projectSpecificLines.length === 0) {
     return trimTrailingEmptyLines(templateLines).join('\n')

--- a/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
+++ b/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
@@ -3,6 +3,13 @@ type MergeGitIgnoreContentOptions = {
   templateContent: string
 }
 
+const PROJECT_SPECIFIC_START_MARKER = '# raijin:begin project-specific gitignore'
+const PROJECT_SPECIFIC_END_MARKER = '# raijin:end project-specific gitignore'
+
+const normalizeContent = (content: string): string => content.replace(/\r\n/g, '\n')
+
+const getNormalizedLines = (content: string): Array<string> => normalizeContent(content).split('\n')
+
 const trimTrailingEmptyLines = (lines: Array<string>): Array<string> => {
   const normalizedLines = [...lines]
 
@@ -13,18 +20,32 @@ const trimTrailingEmptyLines = (lines: Array<string>): Array<string> => {
   return normalizedLines
 }
 
+const getProjectSpecificLines = (
+  existingLines: Array<string>,
+  templateLineSet: Set<string>
+): Array<string> => {
+  const startIndex = existingLines.indexOf(PROJECT_SPECIFIC_START_MARKER)
+  const endIndex = existingLines.indexOf(PROJECT_SPECIFIC_END_MARKER)
+
+  if (startIndex !== -1 && endIndex > startIndex) {
+    return trimTrailingEmptyLines(existingLines.slice(startIndex + 1, endIndex))
+  }
+
+  return existingLines.filter((line) => !templateLineSet.has(line))
+}
+
 export const mergeGitIgnoreContent = ({
   existingContent,
   templateContent,
 }: MergeGitIgnoreContentOptions): string => {
-  const templateLines = templateContent.split('\n')
+  const templateLines = getNormalizedLines(templateContent)
   const templateLineSet = new Set(templateLines)
-  const existingLines = existingContent.split('\n')
+  const existingLines = getNormalizedLines(existingContent)
 
-  const projectSpecificLines = existingLines.filter((line) => !templateLineSet.has(line))
+  const projectSpecificLines = getProjectSpecificLines(existingLines, templateLineSet)
 
   if (projectSpecificLines.length === 0) {
-    return templateContent
+    return trimTrailingEmptyLines(templateLines).join('\n')
   }
 
   const mergedLines = trimTrailingEmptyLines(templateLines)
@@ -33,7 +54,9 @@ export const mergeGitIgnoreContent = ({
     mergedLines.push('')
   }
 
+  mergedLines.push(PROJECT_SPECIFIC_START_MARKER)
   mergedLines.push(...projectSpecificLines)
+  mergedLines.push(PROJECT_SPECIFIC_END_MARKER)
 
   return mergedLines.join('\n')
 }

--- a/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
+++ b/code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.ts
@@ -41,7 +41,7 @@ const getProjectSpecificLines = (
     )
   }
 
-  return existingLines.filter((line) => !templateLineSet.has(line))
+  return existingLines.filter((line) => isProjectSpecificLine(line, templateLineSet))
 }
 
 export const mergeGitIgnoreContent = ({


### PR DESCRIPTION
## Таска
- Close atls/raijin#489

## Как проверять
### До фикса
1. Контекст: повторный запуск schematics (`project.factory`) в проекте с пользовательскими строками в `.gitignore`.
Действие: schematics применяет `MergeStrategy.Overwrite` для common templates.
Ожидаемый результат: пользовательские строки из `.gitignore` теряются, файл заменяется шаблонным.

### После фикса
1. Контекст: `code/code-schematics/src/schematic/project/project.factory.ts`.
Действие: перед merge сохраняется исходный `.gitignore`, после применения шаблонов выполняется детерминированный merge шаблонных и project-specific строк.
Ожидаемый результат: шаблонные правила остаются актуальными, пользовательские строки сохраняются и не дублируются.
2. Контекст: `code/code-schematics/src/schematic/utils/merge-gitignore-content.utils.test.ts`.
Действие: проверяются сценарии merge, идемпотентности и отсутствия дублей.
Ожидаемый результат: тесты покрывают критерии задачи по сохранению и стабильности `.gitignore`.

## Пруфы
- `yarn check` (локально): passed (exit code 0)
- Добавлен merge helper: `mergeGitIgnoreContent(...)`
- Добавлен unit test: `merge-gitignore-content.utils.test.ts`
