### PR TITLE
fix(yarn-cli): rerun rosetta node on native arm64

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -1943,6 +1943,7 @@ const RAW_RUNTIME_STATE =
           ["@atls/yarn-plugin-typescript", "virtual:c7c9eb0e73da0d3b08e1c93a487175d4550637edc7803e366cfe4f5b03b5ee4396f9e6450b2b2bb67fc7215840222e691bb10d7e4ff124152da2c00403c18d78#workspace:yarn/plugin-typescript"],\
           ["@atls/yarn-plugin-ui", "virtual:c7c9eb0e73da0d3b08e1c93a487175d4550637edc7803e366cfe4f5b03b5ee4396f9e6450b2b2bb67fc7215840222e691bb10d7e4ff124152da2c00403c18d78#workspace:yarn/plugin-ui"],\
           ["@atls/yarn-plugin-workspaces", "virtual:c7c9eb0e73da0d3b08e1c93a487175d4550637edc7803e366cfe4f5b03b5ee4396f9e6450b2b2bb67fc7215840222e691bb10d7e4ff124152da2c00403c18d78#workspace:yarn/plugin-workspaces"],\
+          ["@atls/yarn-run-utils", "workspace:yarn/run-utils"],\
           ["@yarnpkg/builder", "patch:@yarnpkg/builder@npm%3A4.1.2#~/.yarn/patches/@yarnpkg-builder-npm-4.1.2-2648882e59.patch::version=4.1.2&hash=a711a8"],\
           ["@yarnpkg/cli", "virtual:ccae17f137fefbbaba6c5ad07c1c85d0eeb7c2d83d1717382e2500f9abd36b42c5a217d63d5beef22301d21ac6bd18bc3e8b2b111a393b68f24ae0ff8b227324#npm:4.5.1"],\
           ["@yarnpkg/core", "npm:4.1.4"],\
@@ -2936,6 +2937,7 @@ const RAW_RUNTIME_STATE =
           ["@atls/cli-ui-test-progress-component", "virtual:c9cca177981ab8ae758413ed8e2c62aac7997e9f921fb7ffe93e264798eaff48c91de930ba59fb05dfcc4b8c1e4d55f34b86a73cb03b67968b44aa61c046f8e7#workspace:cli/cli-ui-test-progress"],\
           ["@atls/code-test", "workspace:code/code-test"],\
           ["@atls/config-typescript", "workspace:config/typescript"],\
+          ["@atls/yarn-run-utils", "workspace:yarn/run-utils"],\
           ["@atls/yarn-test-utils", "workspace:yarn/test-utils"],\
           ["@types/react", "npm:18.3.18"],\
           ["@types/yarnpkg__cli", null],\
@@ -2970,6 +2972,7 @@ const RAW_RUNTIME_STATE =
           ["@atls/cli-ui-test-progress-component", "virtual:c9cca177981ab8ae758413ed8e2c62aac7997e9f921fb7ffe93e264798eaff48c91de930ba59fb05dfcc4b8c1e4d55f34b86a73cb03b67968b44aa61c046f8e7#workspace:cli/cli-ui-test-progress"],\
           ["@atls/code-test", "workspace:code/code-test"],\
           ["@atls/config-typescript", "workspace:config/typescript"],\
+          ["@atls/yarn-run-utils", "workspace:yarn/run-utils"],\
           ["@atls/yarn-test-utils", "workspace:yarn/test-utils"],\
           ["@types/react", "npm:18.3.18"],\
           ["@yarnpkg/builder", "patch:@yarnpkg/builder@npm%3A4.1.2#~/.yarn/patches/@yarnpkg-builder-npm-4.1.2-2648882e59.patch::version=4.1.2&hash=a711a8"],\
@@ -2992,6 +2995,7 @@ const RAW_RUNTIME_STATE =
           ["@atls/yarn-plugin-tools", "workspace:yarn/plugin-tools"],\
           ["@atls/code-runtime", "workspace:runtime/code-runtime"],\
           ["@atls/config-typescript", "workspace:config/typescript"],\
+          ["@atls/yarn-run-utils", "workspace:yarn/run-utils"],\
           ["@types/semver", "npm:7.5.8"],\
           ["@yarnpkg/builder", "patch:@yarnpkg/builder@npm%3A4.1.2#~/.yarn/patches/@yarnpkg-builder-npm-4.1.2-2648882e59.patch::version=4.1.2&hash=a711a8"],\
           ["@yarnpkg/cli", "virtual:ccae17f137fefbbaba6c5ad07c1c85d0eeb7c2d83d1717382e2500f9abd36b42c5a217d63d5beef22301d21ac6bd18bc3e8b2b111a393b68f24ae0ff8b227324#npm:4.5.1"],\
@@ -3162,7 +3166,8 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./yarn/run-utils/",\
         "packageDependencies": [\
           ["@atls/yarn-run-utils", "workspace:yarn/run-utils"],\
-          ["@yarnpkg/core", "npm:4.1.4"]\
+          ["@yarnpkg/core", "npm:4.1.4"],\
+          ["@yarnpkg/fslib", "npm:3.1.0"]\
         ],\
         "linkType": "SOFT"\
       }]\

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,6 +987,7 @@ __metadata:
     "@atls/yarn-plugin-typescript": "workspace:*"
     "@atls/yarn-plugin-ui": "workspace:*"
     "@atls/yarn-plugin-workspaces": "workspace:*"
+    "@atls/yarn-run-utils": "workspace:*"
     "@yarnpkg/builder": "npm:4.2.0"
     "@yarnpkg/cli": "npm:4.5.1"
     "@yarnpkg/core": "npm:4.1.4"
@@ -1450,6 +1451,7 @@ __metadata:
     "@atls/cli-ui-test-progress-component": "workspace:*"
     "@atls/code-test": "workspace:*"
     "@atls/config-typescript": "workspace:*"
+    "@atls/yarn-run-utils": "workspace:*"
     "@atls/yarn-test-utils": "workspace:*"
     "@types/react": "npm:18.3.18"
     "@yarnpkg/builder": "npm:4.2.0"
@@ -1473,6 +1475,7 @@ __metadata:
   dependencies:
     "@atls/code-runtime": "workspace:*"
     "@atls/config-typescript": "workspace:*"
+    "@atls/yarn-run-utils": "workspace:*"
     "@types/semver": "npm:7.5.8"
     "@yarnpkg/builder": "npm:4.2.0"
     "@yarnpkg/cli": "npm:4.5.1"
@@ -1560,6 +1563,7 @@ __metadata:
   resolution: "@atls/yarn-run-utils@workspace:yarn/run-utils"
   dependencies:
     "@yarnpkg/core": "npm:4.1.4"
+    "@yarnpkg/fslib": "npm:3.1.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn/cli/package.json
+++ b/yarn/cli/package.json
@@ -49,6 +49,7 @@
     "@atls/yarn-plugin-typescript": "workspace:*",
     "@atls/yarn-plugin-ui": "workspace:*",
     "@atls/yarn-plugin-workspaces": "workspace:*",
+    "@atls/yarn-run-utils": "workspace:*",
     "@yarnpkg/builder": "4.2.0",
     "@yarnpkg/cli": "4.5.1",
     "@yarnpkg/core": "4.1.4",

--- a/yarn/cli/src/cli.ts
+++ b/yarn/cli/src/cli.ts
@@ -1,29 +1,39 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 
-import { runExit }                from '@yarnpkg/cli'
-import { npath }                  from '@yarnpkg/fslib'
-import { ppath }                  from '@yarnpkg/fslib'
+import { runExit }                             from '@yarnpkg/cli'
+import { npath }                               from '@yarnpkg/fslib'
+import { ppath }                               from '@yarnpkg/fslib'
 
 // @ts-expect-error: Cjs export
-import { getPluginConfiguration } from '@atls/yarn-cli-tools'
+import { getPluginConfiguration }              from '@atls/yarn-cli-tools'
+import { reexecuteYarnWithNativeNodeIfNeeded } from '@atls/yarn-run-utils'
 
-import packageJson                from '../package.json' with { type: 'json' }
+import packageJson                             from '../package.json' with { type: 'json' }
 
 const selfPath = npath.toPortablePath(npath.resolve(process.argv[1]))
-const pc = getPluginConfiguration(packageJson['@yarnpkg/builder'].bundles.standard)
+const nativeNodeExitCode = reexecuteYarnWithNativeNodeIfNeeded({
+  cwd: ppath.cwd(),
+  stderr: process.stderr,
+})
 
-if (pc.then) {
-  pc.then(async (pluginConfiguration: ReturnType<getPluginConfiguration>) => {
+if (typeof nativeNodeExitCode === 'number') {
+  process.exitCode = nativeNodeExitCode
+} else {
+  const pc = getPluginConfiguration(packageJson['@yarnpkg/builder'].bundles.standard)
+
+  if (pc.then) {
+    pc.then(async (pluginConfiguration: ReturnType<getPluginConfiguration>) => {
+      runExit(process.argv.slice(2), {
+        cwd: ppath.cwd(),
+        selfPath,
+        pluginConfiguration,
+      })
+    })
+  } else {
     runExit(process.argv.slice(2), {
       cwd: ppath.cwd(),
       selfPath,
-      pluginConfiguration,
+      pluginConfiguration: pc,
     })
-  })
-} else {
-  runExit(process.argv.slice(2), {
-    cwd: ppath.cwd(),
-    selfPath,
-    pluginConfiguration: pc,
-  })
+  }
 }

--- a/yarn/plugin-checks/sources/checks-lint.command.tsx
+++ b/yarn/plugin-checks/sources/checks-lint.command.tsx
@@ -13,9 +13,7 @@ import { StreamReport }            from '@yarnpkg/core'
 import { Configuration }           from '@yarnpkg/core'
 import { MessageName }             from '@yarnpkg/core'
 import { Project }                 from '@yarnpkg/core'
-import { Filename }                from '@yarnpkg/fslib'
 import { codeFrameColumns }        from '@babel/code-frame'
-import { execUtils }               from '@yarnpkg/core'
 import { scriptUtils }             from '@yarnpkg/core'
 import { xfs }                     from '@yarnpkg/fslib'
 import { npath }                   from '@yarnpkg/fslib'
@@ -26,6 +24,8 @@ import { LintResult }              from '@atls/cli-ui-lint-result-component'
 import { Linter }                  from '@atls/code-lint'
 import { renderStatic }            from '@atls/cli-ui-renderer-static-component'
 import { getChangedFiles }         from '@atls/yarn-plugin-files'
+import { executeYarnPnpProxy }     from '@atls/yarn-run-utils'
+import { pipeYarnPnpProxy }        from '@atls/yarn-run-utils'
 
 import { GitHubChecks }            from './github.checks.js'
 import { AnnotationLevel }         from './github.checks.js'
@@ -36,17 +36,14 @@ class ChecksLintCommand extends BaseCommand {
   changed = Option.Boolean('--changed', false)
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular()
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular()
-    }
-
-    return this.executeProxy()
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular(),
+      executeProxy: async () => this.executeProxy(),
+    })
   }
 
   async executeProxy(): Promise<number> {
@@ -56,7 +53,8 @@ class ChecksLintCommand extends BaseCommand {
     const binFolder = await xfs.mktempPromise()
     const args = ['checks', 'lint', ...(this.changed ? ['--changed'] : [])]
 
-    const { code } = await execUtils.pipevp('yarn', args, {
+    return pipeYarnPnpProxy({
+      args,
       cwd: this.context.cwd,
       stdin: this.context.stdin,
       stdout: this.context.stdout,
@@ -66,8 +64,6 @@ class ChecksLintCommand extends BaseCommand {
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })
-
-    return code
   }
 
   async executeRegular(): Promise<number> {

--- a/yarn/plugin-checks/sources/checks-release.command.ts
+++ b/yarn/plugin-checks/sources/checks-release.command.ts
@@ -3,8 +3,6 @@ import type { Annotation }       from './github.checks.js'
 import { BaseCommand }           from '@yarnpkg/cli'
 import { Configuration }         from '@yarnpkg/core'
 import { Project }               from '@yarnpkg/core'
-import { Filename }              from '@yarnpkg/fslib'
-import { execUtils }             from '@yarnpkg/core'
 import { scriptUtils }           from '@yarnpkg/core'
 import { ppath }                 from '@yarnpkg/fslib'
 import { xfs }                   from '@yarnpkg/fslib'
@@ -12,6 +10,8 @@ import stripAnsi                 from 'strip-ansi'
 
 import { PassThroughRunContext } from '@atls/yarn-run-utils'
 import { getChangedFiles }       from '@atls/yarn-plugin-files'
+import { executeYarnPnpProxy }   from '@atls/yarn-run-utils'
+import { pipeYarnPnpProxy }      from '@atls/yarn-run-utils'
 import { getChangedWorkspaces }  from '@atls/yarn-workspace-utils'
 
 import { GitHubChecks }          from './github.checks.js'
@@ -21,17 +21,14 @@ class ChecksReleaseCommand extends BaseCommand {
   static override paths = [['checks', 'release']]
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular()
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular()
-    }
-
-    return this.executeProxy()
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular(),
+      executeProxy: async () => this.executeProxy(),
+    })
   }
 
   async executeProxy(): Promise<number> {
@@ -40,7 +37,8 @@ class ChecksReleaseCommand extends BaseCommand {
 
     const binFolder = await xfs.mktempPromise()
 
-    const { code } = await execUtils.pipevp('yarn', ['checks', 'release'], {
+    return pipeYarnPnpProxy({
+      args: ['checks', 'release'],
       cwd: this.context.cwd,
       stdin: this.context.stdin,
       stdout: this.context.stdout,
@@ -50,8 +48,6 @@ class ChecksReleaseCommand extends BaseCommand {
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })
-
-    return code
   }
 
   async executeRegular(): Promise<number> {

--- a/yarn/plugin-checks/sources/checks-test-integration.command.ts
+++ b/yarn/plugin-checks/sources/checks-test-integration.command.ts
@@ -4,13 +4,14 @@ import { StreamReport }              from '@yarnpkg/core'
 import { Configuration }             from '@yarnpkg/core'
 import { Project }                   from '@yarnpkg/core'
 import { Filename }                  from '@yarnpkg/fslib'
-import { execUtils }                 from '@yarnpkg/core'
 import { scriptUtils }               from '@yarnpkg/core'
 import { xfs }                       from '@yarnpkg/fslib'
 import { ppath }                     from '@yarnpkg/fslib'
 import { npath }                     from '@yarnpkg/fslib'
 
 import { Tester }                    from '@atls/code-test'
+import { executeYarnPnpProxy }       from '@atls/yarn-run-utils'
+import { pipeYarnPnpProxy }          from '@atls/yarn-run-utils'
 
 import { AbstractChecksTestCommand } from './abstract-checks-test.command.js'
 import { GitHubChecks }              from './github.checks.js'
@@ -19,17 +20,14 @@ class ChecksTestIntegrationCommand extends AbstractChecksTestCommand {
   static override paths = [['checks', 'test', 'integration']]
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular()
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular()
-    }
-
-    return this.executeProxy()
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular(),
+      executeProxy: async () => this.executeProxy(),
+    })
   }
 
   async executeProxy(): Promise<number> {
@@ -60,15 +58,14 @@ class ChecksTestIntegrationCommand extends AbstractChecksTestCommand {
 
     env.COMMAND_PROXY_EXECUTION = 'true'
 
-    const { code } = await execUtils.pipevp('yarn', ['checks', 'test', 'integration'], {
+    return pipeYarnPnpProxy({
+      args: ['checks', 'test', 'integration'],
       cwd: this.context.cwd,
       stdin: this.context.stdin,
       stdout: this.context.stdout,
       stderr: this.context.stderr,
       env,
     })
-
-    return code
   }
 
   async executeRegular(): Promise<number> {

--- a/yarn/plugin-checks/sources/checks-test-unit.command.ts
+++ b/yarn/plugin-checks/sources/checks-test-unit.command.ts
@@ -4,13 +4,14 @@ import { StreamReport }              from '@yarnpkg/core'
 import { Configuration }             from '@yarnpkg/core'
 import { Project }                   from '@yarnpkg/core'
 import { Filename }                  from '@yarnpkg/fslib'
-import { execUtils }                 from '@yarnpkg/core'
 import { scriptUtils }               from '@yarnpkg/core'
 import { xfs }                       from '@yarnpkg/fslib'
 import { ppath }                     from '@yarnpkg/fslib'
 import { npath }                     from '@yarnpkg/fslib'
 
 import { Tester }                    from '@atls/code-test'
+import { executeYarnPnpProxy }       from '@atls/yarn-run-utils'
+import { pipeYarnPnpProxy }          from '@atls/yarn-run-utils'
 
 import { AbstractChecksTestCommand } from './abstract-checks-test.command.js'
 import { GitHubChecks }              from './github.checks.js'
@@ -19,17 +20,14 @@ export class ChecksTestUnitCommand extends AbstractChecksTestCommand {
   static override paths = [['checks', 'test', 'unit']]
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular()
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular()
-    }
-
-    return this.executeProxy()
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular(),
+      executeProxy: async () => this.executeProxy(),
+    })
   }
 
   async executeProxy(): Promise<number> {
@@ -60,15 +58,14 @@ export class ChecksTestUnitCommand extends AbstractChecksTestCommand {
 
     env.COMMAND_PROXY_EXECUTION = 'true'
 
-    const { code } = await execUtils.pipevp('yarn', ['checks', 'test', 'unit'], {
+    return pipeYarnPnpProxy({
+      args: ['checks', 'test', 'unit'],
       cwd: this.context.cwd,
       stdin: this.context.stdin,
       stdout: this.context.stdout,
       stderr: this.context.stderr,
       env,
     })
-
-    return code
   }
 
   async executeRegular(): Promise<number> {

--- a/yarn/plugin-checks/sources/checks-typecheck.command.tsx
+++ b/yarn/plugin-checks/sources/checks-typecheck.command.tsx
@@ -11,9 +11,7 @@ import { Configuration }                from '@yarnpkg/core'
 import { Project }                      from '@yarnpkg/core'
 import { StreamReport }                 from '@yarnpkg/core'
 import { MessageName }                  from '@yarnpkg/core'
-import { Filename }                     from '@yarnpkg/fslib'
 import { codeFrameColumns }             from '@babel/code-frame'
-import { execUtils }                    from '@yarnpkg/core'
 import { scriptUtils }                  from '@yarnpkg/core'
 import { xfs }                          from '@yarnpkg/fslib'
 import { npath }                        from '@yarnpkg/fslib'
@@ -26,6 +24,8 @@ import { TypeScriptDiagnostic }         from '@atls/cli-ui-typescript-diagnostic
 import { TypeScript }                   from '@atls/code-typescript'
 import { renderStatic }                 from '@atls/cli-ui-renderer-static-component'
 import { getChangedFiles }              from '@atls/yarn-plugin-files'
+import { executeYarnPnpProxy }          from '@atls/yarn-run-utils'
+import { pipeYarnPnpProxy }             from '@atls/yarn-run-utils'
 
 import { GitHubChecks }                 from './github.checks.js'
 import { AnnotationLevel }              from './github.checks.js'
@@ -34,17 +34,14 @@ class ChecksTypeCheckCommand extends BaseCommand {
   static override paths = [['checks', 'typecheck']]
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular()
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular()
-    }
-
-    return this.executeProxy()
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular(),
+      executeProxy: async () => this.executeProxy(),
+    })
   }
 
   async executeProxy(): Promise<number> {
@@ -54,7 +51,8 @@ class ChecksTypeCheckCommand extends BaseCommand {
     const binFolder = await xfs.mktempPromise()
     const args = ['checks', 'typecheck', ...(this.changed ? ['--changed'] : [])]
 
-    const { code } = await execUtils.pipevp('yarn', args, {
+    return pipeYarnPnpProxy({
+      args,
       cwd: this.context.cwd,
       stdin: this.context.stdin,
       stdout: this.context.stdout,
@@ -64,8 +62,6 @@ class ChecksTypeCheckCommand extends BaseCommand {
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })
-
-    return code
   }
 
   async executeRegular(): Promise<number> {

--- a/yarn/plugin-checks/sources/proxy-corepack-env.guard.test.js
+++ b/yarn/plugin-checks/sources/proxy-corepack-env.guard.test.js
@@ -25,7 +25,7 @@ const TARGET_SOURCE_DIRS = [
 ]
 
 const YARN_REENTRY_REGEXP =
-  /\b(?:execUtils\.)?(?:pipevp|execvp)\(\s*['"]yarn['"]|\bspawn\(\s*['"]yarn['"]/g
+  /\bpipeYarnPnpProxy\(\s*\{|\b(?:execUtils\.)?(?:pipevp|execvp)\(\s*['"]yarn['"]|\bspawn\(\s*['"]yarn['"]/g
 
 const SCRIPT_ENV_REGEXP = /scriptUtils\.makeScriptEnv\(\s*\{[\s\S]*?\}\s*\)/g
 

--- a/yarn/plugin-library/sources/library-build.command.tsx
+++ b/yarn/plugin-library/sources/library-build.command.tsx
@@ -4,9 +4,7 @@ import { join }                 from 'node:path'
 import { BaseCommand }          from '@yarnpkg/cli'
 import { Configuration }        from '@yarnpkg/core'
 import { Project }              from '@yarnpkg/core'
-import { Filename }             from '@yarnpkg/fslib'
 import { scriptUtils }          from '@yarnpkg/core'
-import { execUtils }            from '@yarnpkg/core'
 import { xfs }                  from '@yarnpkg/fslib'
 import { Option }               from 'clipanion'
 import { render }               from 'ink'
@@ -17,6 +15,8 @@ import { TypeScriptDiagnostic } from '@atls/cli-ui-typescript-diagnostic-compone
 import { TypeScriptProgress }   from '@atls/cli-ui-typescript-progress-component'
 import { TypeScript }           from '@atls/code-typescript'
 import { renderStatic }         from '@atls/cli-ui-renderer-static-component'
+import { executeYarnPnpProxy }  from '@atls/yarn-run-utils'
+import { pipeYarnPnpProxy }     from '@atls/yarn-run-utils'
 
 export class LibraryBuildCommand extends BaseCommand {
   static override paths = [['library', 'build']]
@@ -24,17 +24,14 @@ export class LibraryBuildCommand extends BaseCommand {
   target = Option.String('-t,--target', './dist')
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular()
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular()
-    }
-
-    return this.executeProxy()
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular(),
+      executeProxy: async () => this.executeProxy(),
+    })
   }
 
   async executeProxy(): Promise<number> {
@@ -50,7 +47,8 @@ export class LibraryBuildCommand extends BaseCommand {
 
     const binFolder = await xfs.mktempPromise()
 
-    const { code } = await execUtils.pipevp('yarn', ['library', 'build', ...args], {
+    return pipeYarnPnpProxy({
+      args: ['library', 'build', ...args],
       cwd: this.context.cwd,
       stdin: this.context.stdin,
       stdout: this.context.stdout,
@@ -60,8 +58,6 @@ export class LibraryBuildCommand extends BaseCommand {
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })
-
-    return code
   }
 
   async executeRegular(): Promise<number> {

--- a/yarn/plugin-lint/sources/lint.command.tsx
+++ b/yarn/plugin-lint/sources/lint.command.tsx
@@ -1,19 +1,19 @@
-import { BaseCommand }   from '@yarnpkg/cli'
-import { Configuration } from '@yarnpkg/core'
-import { Project }       from '@yarnpkg/core'
-import { Filename }      from '@yarnpkg/fslib'
-import { execUtils }     from '@yarnpkg/core'
-import { scriptUtils }   from '@yarnpkg/core'
-import { xfs }           from '@yarnpkg/fslib'
-import { Option }        from 'clipanion'
-import { render }        from 'ink'
-import React             from 'react'
+import { BaseCommand }         from '@yarnpkg/cli'
+import { Configuration }       from '@yarnpkg/core'
+import { Project }             from '@yarnpkg/core'
+import { scriptUtils }         from '@yarnpkg/core'
+import { xfs }                 from '@yarnpkg/fslib'
+import { Option }              from 'clipanion'
+import { render }              from 'ink'
+import React                   from 'react'
 
-import { ErrorInfo }     from '@atls/cli-ui-error-info-component'
-import { LintProgress }  from '@atls/cli-ui-lint-progress-component'
-import { LintResult }    from '@atls/cli-ui-lint-result-component'
-import { Linter }        from '@atls/code-lint'
-import { renderStatic }  from '@atls/cli-ui-renderer-static-component'
+import { ErrorInfo }           from '@atls/cli-ui-error-info-component'
+import { LintProgress }        from '@atls/cli-ui-lint-progress-component'
+import { LintResult }          from '@atls/cli-ui-lint-result-component'
+import { Linter }              from '@atls/code-lint'
+import { renderStatic }        from '@atls/cli-ui-renderer-static-component'
+import { executeYarnPnpProxy } from '@atls/yarn-run-utils'
+import { pipeYarnPnpProxy }    from '@atls/yarn-run-utils'
 
 export class LintCommand extends BaseCommand {
   static override paths = [['lint']]
@@ -25,17 +25,14 @@ export class LintCommand extends BaseCommand {
   cache: boolean = Option.Boolean('--cache', false)
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular()
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular()
-    }
-
-    return this.executeProxy()
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular(),
+      executeProxy: async () => this.executeProxy(),
+    })
   }
 
   async executeProxy(): Promise<number> {
@@ -54,7 +51,8 @@ export class LintCommand extends BaseCommand {
       args.push('--cache')
     }
 
-    const { code } = await execUtils.pipevp('yarn', ['lint', ...args, ...this.files], {
+    return pipeYarnPnpProxy({
+      args: ['lint', ...args, ...this.files],
       cwd: this.context.cwd,
       stdin: this.context.stdin,
       stdout: this.context.stdout,
@@ -64,8 +62,6 @@ export class LintCommand extends BaseCommand {
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })
-
-    return code
   }
 
   async executeRegular(): Promise<number> {

--- a/yarn/plugin-service/sources/service-build.command.tsx
+++ b/yarn/plugin-service/sources/service-build.command.tsx
@@ -1,16 +1,15 @@
 import { Configuration }          from '@yarnpkg/core'
 import { Project }                from '@yarnpkg/core'
-import { Filename }               from '@yarnpkg/fslib'
 import { scriptUtils }            from '@yarnpkg/core'
-import { execUtils }              from '@yarnpkg/core'
 import { xfs }                    from '@yarnpkg/fslib'
 import { render }                 from 'ink'
 import React                      from 'react'
 
 import { ErrorInfo }              from '@atls/cli-ui-error-info-component'
 import { ServiceProgress }        from '@atls/cli-ui-service-progress-component'
-import { Service }                from '@atls/code-service'
 import { renderStatic }           from '@atls/cli-ui-renderer-static-component'
+import { executeYarnPnpProxy }    from '@atls/yarn-run-utils'
+import { pipeYarnPnpProxy }       from '@atls/yarn-run-utils'
 
 import { AbstractServiceCommand } from './abstract-service.command.jsx'
 
@@ -18,17 +17,14 @@ export class ServiceBuildCommand extends AbstractServiceCommand {
   static override paths = [['service', 'build']]
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular()
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular()
-    }
-
-    return this.executeProxy()
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular(),
+      executeProxy: async () => this.executeProxy(),
+    })
   }
 
   async executeProxy(): Promise<number> {
@@ -43,7 +39,8 @@ export class ServiceBuildCommand extends AbstractServiceCommand {
 
     const binFolder = await xfs.mktempPromise()
 
-    const { code } = await execUtils.pipevp('yarn', ['service', 'build', ...args], {
+    return pipeYarnPnpProxy({
+      args: ['service', 'build', ...args],
       cwd: this.context.cwd,
       stdin: this.context.stdin,
       stdout: this.context.stdout,
@@ -53,11 +50,10 @@ export class ServiceBuildCommand extends AbstractServiceCommand {
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })
-
-    return code
   }
 
   async executeRegular(): Promise<number> {
+    const { Service } = await import('@atls/code-service')
     const service = await Service.initialize(this.context.cwd)
 
     const { clear } = render(<ServiceProgress service={service} />)

--- a/yarn/plugin-service/sources/service-dev.command.tsx
+++ b/yarn/plugin-service/sources/service-dev.command.tsx
@@ -1,14 +1,13 @@
 import { Configuration }          from '@yarnpkg/core'
 import { Project }                from '@yarnpkg/core'
-import { Filename }               from '@yarnpkg/fslib'
 import { scriptUtils }            from '@yarnpkg/core'
-import { execUtils }              from '@yarnpkg/core'
 import { xfs }                    from '@yarnpkg/fslib'
 import { render }                 from 'ink'
 import React                      from 'react'
 
 import { ServiceProgress }        from '@atls/cli-ui-service-progress-component'
-import { Service }                from '@atls/code-service'
+import { executeYarnPnpProxy }    from '@atls/yarn-run-utils'
+import { pipeYarnPnpProxy }       from '@atls/yarn-run-utils'
 
 import { AbstractServiceCommand } from './abstract-service.command.jsx'
 
@@ -16,17 +15,14 @@ export class ServiceDevCommand extends AbstractServiceCommand {
   static override paths = [['service', 'dev']]
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular()
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular()
-    }
-
-    return this.executeProxy()
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular(),
+      executeProxy: async () => this.executeProxy(),
+    })
   }
 
   async executeProxy(): Promise<number> {
@@ -41,7 +37,8 @@ export class ServiceDevCommand extends AbstractServiceCommand {
 
     const binFolder = await xfs.mktempPromise()
 
-    const { code } = await execUtils.pipevp('yarn', ['service', 'dev', ...args], {
+    return pipeYarnPnpProxy({
+      args: ['service', 'dev', ...args],
       cwd: this.context.cwd,
       stdin: this.context.stdin,
       stdout: this.context.stdout,
@@ -51,11 +48,10 @@ export class ServiceDevCommand extends AbstractServiceCommand {
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })
-
-    return code
   }
 
   async executeRegular(): Promise<number> {
+    const { Service } = await import('@atls/code-service')
     const service = await Service.initialize(this.context.cwd)
 
     const { clear } = render(<ServiceProgress service={service} />)

--- a/yarn/plugin-test/package.json
+++ b/yarn/plugin-test/package.json
@@ -24,6 +24,7 @@
     "@atls/cli-ui-test-failure-component": "workspace:*",
     "@atls/cli-ui-test-progress-component": "workspace:*",
     "@atls/code-test": "workspace:*",
+    "@atls/yarn-run-utils": "workspace:*",
     "clipanion": "4.0.0-rc.2",
     "ink": "3.2.0",
     "react": "18.3.1",

--- a/yarn/plugin-test/sources/abstract-test.command.tsx
+++ b/yarn/plugin-test/sources/abstract-test.command.tsx
@@ -1,31 +1,31 @@
 /* eslint-disable n/no-sync */
 
-import { readFileSync }  from 'node:fs'
-import { relative }      from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { readFileSync }     from 'node:fs'
+import { relative }         from 'node:path'
+import { pathToFileURL }    from 'node:url'
 
-import { BaseCommand }   from '@yarnpkg/cli'
-import { Configuration } from '@yarnpkg/core'
-import { Project }       from '@yarnpkg/core'
-import { Filename }      from '@yarnpkg/fslib'
-import { scriptUtils }   from '@yarnpkg/core'
-import { execUtils }     from '@yarnpkg/core'
-import { xfs }           from '@yarnpkg/fslib'
-import { ppath }         from '@yarnpkg/fslib'
-import { npath }         from '@yarnpkg/fslib'
-import { Option }        from 'clipanion'
-import { Command }       from 'clipanion'
-import { render }        from 'ink'
-import { isEnum }        from 'typanion'
-import React             from 'react'
+import { BaseCommand }      from '@yarnpkg/cli'
+import { Configuration }    from '@yarnpkg/core'
+import { Project }          from '@yarnpkg/core'
+import { Filename }         from '@yarnpkg/fslib'
+import { scriptUtils }      from '@yarnpkg/core'
+import { xfs }              from '@yarnpkg/fslib'
+import { ppath }            from '@yarnpkg/fslib'
+import { npath }            from '@yarnpkg/fslib'
+import { Option }           from 'clipanion'
+import { Command }          from 'clipanion'
+import { render }           from 'ink'
+import { isEnum }           from 'typanion'
+import React                from 'react'
 
-import { ErrorInfo }     from '@atls/cli-ui-error-info-component'
-import { LogRecord }     from '@atls/cli-ui-log-record-component'
-import { RawOutput }     from '@atls/cli-ui-raw-output-component'
-import { TestFailure }   from '@atls/cli-ui-test-failure-component'
-import { TestProgress }  from '@atls/cli-ui-test-progress-component'
-import { Tester }        from '@atls/code-test'
-import { renderStatic }  from '@atls/cli-ui-renderer-static-component'
+import { ErrorInfo }        from '@atls/cli-ui-error-info-component'
+import { LogRecord }        from '@atls/cli-ui-log-record-component'
+import { RawOutput }        from '@atls/cli-ui-raw-output-component'
+import { TestFailure }      from '@atls/cli-ui-test-failure-component'
+import { TestProgress }     from '@atls/cli-ui-test-progress-component'
+import { Tester }           from '@atls/code-test'
+import { renderStatic }     from '@atls/cli-ui-renderer-static-component'
+import { pipeYarnPnpProxy } from '@atls/yarn-run-utils'
 
 export abstract class AbstractTestCommand extends BaseCommand {
   static override usage = Command.Usage({
@@ -113,15 +113,14 @@ export abstract class AbstractTestCommand extends BaseCommand {
 
     env.COMMAND_PROXY_EXECUTION = 'true'
 
-    const { code } = await execUtils.pipevp('yarn', ['test', type ?? '', ...args], {
+    return pipeYarnPnpProxy({
+      args: ['test', type ?? '', ...args],
       cwd: project.cwd,
       stdin: this.context.stdin,
       stdout: this.context.stdout,
       stderr: this.context.stderr,
       env,
     })
-
-    return code
   }
 
   async executeRegular(type: 'integration' | 'unit'): Promise<number> {

--- a/yarn/plugin-test/sources/test-integration.command.ts
+++ b/yarn/plugin-test/sources/test-integration.command.ts
@@ -1,4 +1,4 @@
-import { Filename }            from '@yarnpkg/fslib'
+import { executeYarnPnpProxy } from '@atls/yarn-run-utils'
 
 import { AbstractTestCommand } from './abstract-test.command.jsx'
 
@@ -6,16 +6,13 @@ export class TestIntegrationCommand extends AbstractTestCommand {
   static override paths = [['test', 'integration']]
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular('integration')
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular('integration')
-    }
-
-    return this.executeProxy('integration')
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular('integration'),
+      executeProxy: async () => this.executeProxy('integration'),
+    })
   }
 }

--- a/yarn/plugin-test/sources/test-unit.command.ts
+++ b/yarn/plugin-test/sources/test-unit.command.ts
@@ -1,4 +1,4 @@
-import { Filename }            from '@yarnpkg/fslib'
+import { executeYarnPnpProxy } from '@atls/yarn-run-utils'
 
 import { AbstractTestCommand } from './abstract-test.command.jsx'
 
@@ -6,16 +6,13 @@ export class TestUnitCommand extends AbstractTestCommand {
   static override paths = [['test', 'unit']]
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular('unit')
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular('unit')
-    }
-
-    return this.executeProxy('unit')
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular('unit'),
+      executeProxy: async () => this.executeProxy('unit'),
+    })
   }
 }

--- a/yarn/plugin-test/sources/test.command.ts
+++ b/yarn/plugin-test/sources/test.command.ts
@@ -1,8 +1,8 @@
 import { Configuration }       from '@yarnpkg/core'
 import { Project }             from '@yarnpkg/core'
-import { Filename }            from '@yarnpkg/fslib'
 
 import { Tester }              from '@atls/code-test'
+import { executeYarnPnpProxy } from '@atls/yarn-run-utils'
 
 import { AbstractTestCommand } from './abstract-test.command.jsx'
 
@@ -10,17 +10,14 @@ export class TestCommand extends AbstractTestCommand {
   static override paths = [['test']]
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular()
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular()
-    }
-
-    return this.executeProxy()
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular(),
+      executeProxy: async () => this.executeProxy(),
+    })
   }
 
   override async executeRegular(): Promise<number> {

--- a/yarn/plugin-tools/package.json
+++ b/yarn/plugin-tools/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@atls/code-runtime": "workspace:*",
     "@atls/config-typescript": "workspace:*",
+    "@atls/yarn-run-utils": "workspace:*",
     "clipanion": "4.0.0-rc.2",
     "deepmerge": "4.3.1",
     "husky": "9.1.7",

--- a/yarn/plugin-tools/sources/commands/sync/abstract-tools.command.ts
+++ b/yarn/plugin-tools/sources/commands/sync/abstract-tools.command.ts
@@ -1,11 +1,12 @@
-import { BaseCommand }   from '@yarnpkg/cli'
-import { Configuration } from '@yarnpkg/core'
-import { Project }       from '@yarnpkg/core'
-import { Filename }      from '@yarnpkg/fslib'
-import { scriptUtils }   from '@yarnpkg/core'
-import { execUtils }     from '@yarnpkg/core'
-import { xfs }           from '@yarnpkg/fslib'
-import { Command }       from 'clipanion'
+import { BaseCommand }         from '@yarnpkg/cli'
+import { Configuration }       from '@yarnpkg/core'
+import { Project }             from '@yarnpkg/core'
+import { scriptUtils }         from '@yarnpkg/core'
+import { xfs }                 from '@yarnpkg/fslib'
+import { Command }             from 'clipanion'
+
+import { executeYarnPnpProxy } from '@atls/yarn-run-utils'
+import { pipeYarnPnpProxy }    from '@atls/yarn-run-utils'
 
 export abstract class AbstractToolsCommand extends BaseCommand {
   static override usage = Command.Usage({
@@ -22,17 +23,14 @@ export abstract class AbstractToolsCommand extends BaseCommand {
   })
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular()
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular()
-    }
-
-    return this.executeProxy()
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular(),
+      executeProxy: async () => this.executeProxy(),
+    })
   }
 
   async executeProxy(command: Array<string> = ['tools', 'sync']): Promise<number> {
@@ -41,7 +39,8 @@ export abstract class AbstractToolsCommand extends BaseCommand {
 
     const binFolder = await xfs.mktempPromise()
 
-    const { code } = await execUtils.pipevp('yarn', command, {
+    return pipeYarnPnpProxy({
+      args: command,
       cwd: this.context.cwd,
       stdin: this.context.stdin,
       stdout: this.context.stdout,
@@ -51,8 +50,6 @@ export abstract class AbstractToolsCommand extends BaseCommand {
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })
-
-    return code
   }
 
   async executeRegular(): Promise<number> {

--- a/yarn/plugin-tools/sources/commands/sync/tools-sync-tsconfig.command.ts
+++ b/yarn/plugin-tools/sources/commands/sync/tools-sync-tsconfig.command.ts
@@ -5,11 +5,11 @@ import assert                   from 'node:assert'
 import { Configuration }        from '@yarnpkg/core'
 import { Project }              from '@yarnpkg/core'
 import { StreamReport }         from '@yarnpkg/core'
-import { Filename }             from '@yarnpkg/fslib'
 import { xfs }                  from '@yarnpkg/fslib'
 import { ppath }                from '@yarnpkg/fslib'
 import deepmerge                from 'deepmerge'
 
+import { executeYarnPnpProxy }  from '@atls/yarn-run-utils'
 import tsconfig                 from '@atls/config-typescript'
 
 import { AbstractToolsCommand } from './abstract-tools.command.js'
@@ -55,17 +55,14 @@ export class ToolsSyncTSConfigCommand extends AbstractToolsCommand {
   static override paths = [['tools', 'sync', 'tsconfig']]
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular()
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular()
-    }
-
-    return this.executeProxy(['tools', 'sync', 'tsconfig'])
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular(),
+      executeProxy: async () => this.executeProxy(['tools', 'sync', 'tsconfig']),
+    })
   }
 
   override async executeRegular(): Promise<number> {

--- a/yarn/plugin-tools/sources/commands/sync/tools-sync-typescript.command.ts
+++ b/yarn/plugin-tools/sources/commands/sync/tools-sync-typescript.command.ts
@@ -1,9 +1,10 @@
 import { Configuration }        from '@yarnpkg/core'
 import { Project }              from '@yarnpkg/core'
 import { StreamReport }         from '@yarnpkg/core'
-import { Filename }             from '@yarnpkg/fslib'
 import { structUtils }          from '@yarnpkg/core'
 import semver                   from 'semver'
+
+import { executeYarnPnpProxy }  from '@atls/yarn-run-utils'
 
 import { AbstractToolsCommand } from './abstract-tools.command.js'
 
@@ -11,17 +12,14 @@ export class ToolsSyncTypeScriptCommand extends AbstractToolsCommand {
   static override paths = [['tools', 'sync', 'typescript']]
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular()
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular()
-    }
-
-    return this.executeProxy(['tools', 'sync', 'typescript'])
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular(),
+      executeProxy: async () => this.executeProxy(['tools', 'sync', 'typescript']),
+    })
   }
 
   override async executeRegular(): Promise<number> {

--- a/yarn/plugin-typescript/sources/typecheck.command.tsx
+++ b/yarn/plugin-typescript/sources/typecheck.command.tsx
@@ -1,9 +1,7 @@
 import { BaseCommand }          from '@yarnpkg/cli'
 import { Configuration }        from '@yarnpkg/core'
 import { Project }              from '@yarnpkg/core'
-import { Filename }             from '@yarnpkg/fslib'
 import { scriptUtils }          from '@yarnpkg/core'
-import { execUtils }            from '@yarnpkg/core'
 import { ppath }                from '@yarnpkg/fslib'
 import { xfs }                  from '@yarnpkg/fslib'
 import { Option }               from 'clipanion'
@@ -15,6 +13,8 @@ import { TypeScriptDiagnostic } from '@atls/cli-ui-typescript-diagnostic-compone
 import { TypeScriptProgress }   from '@atls/cli-ui-typescript-progress-component'
 import { TypeScript }           from '@atls/code-typescript'
 import { renderStatic }         from '@atls/cli-ui-renderer-static-component'
+import { executeYarnPnpProxy }  from '@atls/yarn-run-utils'
+import { pipeYarnPnpProxy }     from '@atls/yarn-run-utils'
 
 export class TypeCheckCommand extends BaseCommand {
   static override paths = [['typecheck']]
@@ -22,17 +22,14 @@ export class TypeCheckCommand extends BaseCommand {
   args: Array<string> = Option.Rest({ required: 0 })
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular()
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular()
-    }
-
-    return this.executeProxy()
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular(),
+      executeProxy: async () => this.executeProxy(),
+    })
   }
 
   async executeProxy(): Promise<number> {
@@ -41,7 +38,8 @@ export class TypeCheckCommand extends BaseCommand {
 
     const binFolder = await xfs.mktempPromise()
 
-    const { code } = await execUtils.pipevp('yarn', ['typecheck', ...this.args], {
+    return pipeYarnPnpProxy({
+      args: ['typecheck', ...this.args],
       cwd: this.context.cwd,
       stdin: this.context.stdin,
       stdout: this.context.stdout,
@@ -51,8 +49,6 @@ export class TypeCheckCommand extends BaseCommand {
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })
-
-    return code
   }
 
   async executeRegular(): Promise<number> {

--- a/yarn/plugin-ui/package.json
+++ b/yarn/plugin-ui/package.json
@@ -22,13 +22,13 @@
     "@atls/cli-ui-icons-progress-component": "workspace:*",
     "@atls/cli-ui-renderer-static-component": "workspace:*",
     "@atls/code-icons": "workspace:*",
+    "@atls/yarn-run-utils": "workspace:*",
     "clipanion": "4.0.0-rc.2",
     "globby": "13.2.2",
     "ink": "3.2.0",
     "react": "18.3.1"
   },
   "devDependencies": {
-    "@atls/yarn-run-utils": "workspace:*",
     "@atls/yarn-test-utils": "workspace:*",
     "@types/react": "18.3.18",
     "@yarnpkg/builder": "4.2.0",

--- a/yarn/plugin-ui/sources/commands/ui-icons-generate.command.tsx
+++ b/yarn/plugin-ui/sources/commands/ui-icons-generate.command.tsx
@@ -1,22 +1,22 @@
-import { join }          from 'node:path'
-import { relative }      from 'node:path'
+import { join }                from 'node:path'
+import { relative }            from 'node:path'
 
-import { BaseCommand }   from '@yarnpkg/cli'
-import { Configuration } from '@yarnpkg/core'
-import { Project }       from '@yarnpkg/core'
-import { Filename }      from '@yarnpkg/fslib'
-import { execUtils }     from '@yarnpkg/core'
-import { scriptUtils }   from '@yarnpkg/core'
-import { xfs }           from '@yarnpkg/fslib'
-import { Option }        from 'clipanion'
-import { globby }        from 'globby'
-import { render }        from 'ink'
-import React             from 'react'
+import { BaseCommand }         from '@yarnpkg/cli'
+import { Configuration }       from '@yarnpkg/core'
+import { Project }             from '@yarnpkg/core'
+import { scriptUtils }         from '@yarnpkg/core'
+import { xfs }                 from '@yarnpkg/fslib'
+import { Option }              from 'clipanion'
+import { globby }              from 'globby'
+import { render }              from 'ink'
+import React                   from 'react'
 
-import { ErrorInfo }     from '@atls/cli-ui-error-info-component'
-import { IconsProgress } from '@atls/cli-ui-icons-progress-component'
-import { Icons }         from '@atls/code-icons'
-import { renderStatic }  from '@atls/cli-ui-renderer-static-component'
+import { ErrorInfo }           from '@atls/cli-ui-error-info-component'
+import { IconsProgress }       from '@atls/cli-ui-icons-progress-component'
+import { Icons }               from '@atls/code-icons'
+import { renderStatic }        from '@atls/cli-ui-renderer-static-component'
+import { executeYarnPnpProxy } from '@atls/yarn-run-utils'
+import { pipeYarnPnpProxy }    from '@atls/yarn-run-utils'
 
 export class UiIconsGenerateCommand extends BaseCommand {
   static override paths = [['ui', 'icons', 'generate']]
@@ -24,17 +24,14 @@ export class UiIconsGenerateCommand extends BaseCommand {
   native: boolean = Option.Boolean('-n, --native', false)
 
   override async execute(): Promise<number> {
-    const nodeOptions = process.env.NODE_OPTIONS ?? ''
-
-    if (nodeOptions.includes(Filename.pnpCjs) && nodeOptions.includes(Filename.pnpEsmLoader)) {
-      return this.executeRegular()
-    }
-
-    if (process.env.COMMAND_PROXY_EXECUTION === 'true') {
-      return this.executeRegular()
-    }
-
-    return this.executeProxy()
+    return executeYarnPnpProxy({
+      cwd: this.context.cwd,
+      stdin: this.context.stdin,
+      stdout: this.context.stdout,
+      stderr: this.context.stderr,
+      executeRegular: async () => this.executeRegular(),
+      executeProxy: async () => this.executeProxy(),
+    })
   }
 
   async executeProxy(): Promise<number> {
@@ -49,7 +46,8 @@ export class UiIconsGenerateCommand extends BaseCommand {
       args.push('--native')
     }
 
-    const { code } = await execUtils.pipevp('yarn', ['ui', 'icons', 'generate', ...args], {
+    return pipeYarnPnpProxy({
+      args: ['ui', 'icons', 'generate', ...args],
       cwd: this.context.cwd,
       stdin: this.context.stdin,
       stdout: this.context.stdout,
@@ -59,8 +57,6 @@ export class UiIconsGenerateCommand extends BaseCommand {
         COMMAND_PROXY_EXECUTION: 'true',
       },
     })
-
-    return code
   }
 
   async executeRegular(): Promise<number> {

--- a/yarn/run-utils/package.json
+++ b/yarn/run-utils/package.json
@@ -12,7 +12,8 @@
     "dist"
   ],
   "dependencies": {
-    "@yarnpkg/core": "4.1.4"
+    "@yarnpkg/core": "4.1.4",
+    "@yarnpkg/fslib": "3.1.0"
   },
   "publishConfig": {
     "access": "public",

--- a/yarn/run-utils/sources/index.ts
+++ b/yarn/run-utils/sources/index.ts
@@ -1,3 +1,4 @@
 export * from './pass-through-run.context.js'
 export * from './stream.output.js'
 export * from './spinner.progress.js'
+export * from './yarn-pnp-proxy.js'

--- a/yarn/run-utils/sources/yarn-pnp-proxy.test.js
+++ b/yarn/run-utils/sources/yarn-pnp-proxy.test.js
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import { delimiter } from 'node:path'
+import { resolve } from 'node:path'
+import { test } from 'node:test'
+
+import { COMMAND_PROXY_EXECUTION } from './yarn-pnp-proxy.js'
+import { NATIVE_NODE_PATH } from './yarn-pnp-proxy.js'
+import { getNativeNodeCandidates } from './yarn-pnp-proxy.js'
+import { hasPnpLoaders } from './yarn-pnp-proxy.js'
+import { isRosettaRuntime } from './yarn-pnp-proxy.js'
+import { isYarnPnpRegularRuntime } from './yarn-pnp-proxy.js'
+import { resolveNativeArm64NodePath } from './yarn-pnp-proxy.js'
+
+test('should detect yarn pnp regular runtime', () => {
+  assert.equal(
+    hasPnpLoaders('--require /repo/.pnp.cjs --loader file:///repo/.pnp.loader.mjs'),
+    true
+  )
+  assert.equal(hasPnpLoaders('--require /repo/.pnp.cjs'), false)
+  assert.equal(isYarnPnpRegularRuntime({ NODE_OPTIONS: '--require /repo/.pnp.cjs' }), false)
+  assert.equal(
+    isYarnPnpRegularRuntime({
+      [COMMAND_PROXY_EXECUTION]: 'true',
+    }),
+    true
+  )
+})
+
+test('should detect Rosetta runtime only for translated darwin x64 process', () => {
+  assert.equal(isRosettaRuntime({ platform: 'darwin', arch: 'x64', translated: true }), true)
+  assert.equal(isRosettaRuntime({ platform: 'darwin', arch: 'arm64', translated: true }), false)
+  assert.equal(isRosettaRuntime({ platform: 'linux', arch: 'x64', translated: true }), false)
+  assert.equal(isRosettaRuntime({ platform: 'darwin', arch: 'x64', translated: false }), false)
+})
+
+test('should prefer explicit and nvm node candidates before path fallbacks', () => {
+  const env = {
+    [NATIVE_NODE_PATH]: '/custom/bin/node',
+    NVM_BIN: '/Users/user/.nvm/versions/node/v24.11.1/bin',
+    PATH: ['/usr/local/bin', '/opt/homebrew/bin'].join(delimiter),
+  }
+
+  assert.deepEqual(getNativeNodeCandidates(env, '/usr/local/bin/node').slice(0, 3), [
+    resolve('/custom/bin/node'),
+    resolve('/Users/user/.nvm/versions/node/v24.11.1/bin/node'),
+    resolve('/opt/homebrew/bin/node'),
+  ])
+})
+
+test('should resolve first arm64 node candidate', () => {
+  const env = {
+    PATH: ['/x64/bin', '/arm/bin'].join(delimiter),
+  }
+
+  const resolved = resolveNativeArm64NodePath({
+    env,
+    execPath: '/current/bin/node',
+    inspectNodeArchitecture: (nodePath) => (nodePath.includes('/arm/') ? 'arm64' : 'x64'),
+  })
+
+  assert.equal(resolved, resolve('/arm/bin/node'))
+})

--- a/yarn/run-utils/sources/yarn-pnp-proxy.ts
+++ b/yarn/run-utils/sources/yarn-pnp-proxy.ts
@@ -1,0 +1,289 @@
+/* eslint-disable n/no-sync */
+
+import type { PortablePath } from '@yarnpkg/fslib'
+import type { Readable }     from 'node:stream'
+import type { Writable }     from 'node:stream'
+
+import { spawnSync }         from 'node:child_process'
+import { readdirSync }       from 'node:fs'
+import { delimiter }         from 'node:path'
+import { join }              from 'node:path'
+import { resolve }           from 'node:path'
+
+import { execUtils }         from '@yarnpkg/core'
+
+export const COMMAND_PROXY_EXECUTION = 'COMMAND_PROXY_EXECUTION'
+
+export const NATIVE_NODE_REEXECUTION = 'ATLS_YARN_NATIVE_NODE_REEXECUTION'
+
+export const ALLOW_ROSETTA_NODE = 'ATLS_YARN_ALLOW_ROSETTA_NODE'
+
+export const NATIVE_NODE_PATH = 'ATLS_YARN_NATIVE_NODE'
+
+const PNP_CJS_LOADER = '.pnp.cjs'
+
+const PNP_ESM_LOADER = '.pnp.loader.mjs'
+
+const NODE_ARCH_SCRIPT = 'process.stdout.write(process.arch)'
+
+const ROSETTA_SYSCTL_KEY = 'sysctl.proc_translated'
+
+const NODE_INSPECTION_TIMEOUT = 5000
+
+export interface RuntimeState {
+  platform: NodeJS.Platform
+
+  arch: string
+
+  translated: boolean
+}
+
+export interface YarnPnpProxyOptions {
+  cwd: PortablePath
+
+  stdin: Readable
+
+  stdout: Writable
+
+  stderr: Writable
+
+  executeRegular: () => Promise<number>
+
+  executeProxy: () => Promise<number>
+}
+
+export interface YarnPnpProxyPipeOptions {
+  args: Array<string>
+
+  cwd: PortablePath
+
+  stdin: Readable
+
+  stdout: Writable
+
+  stderr: Writable
+
+  env: NodeJS.ProcessEnv
+}
+
+export interface YarnPnpNativeNodeOptions {
+  cwd: PortablePath
+
+  stderr: Writable
+}
+
+export interface NativeNodeResolutionOptions {
+  env?: NodeJS.ProcessEnv
+
+  execPath?: string
+
+  inspectNodeArchitecture?: (nodePath: string, env: NodeJS.ProcessEnv) => string | undefined
+}
+
+const getPathNodeCandidates = (path: string | undefined): Array<string> =>
+  (path ?? '')
+    .split(delimiter)
+    .filter(Boolean)
+    .map((pathPart) => join(pathPart, 'node'))
+
+const getNvmNodeCandidates = (env: NodeJS.ProcessEnv): Array<string> => {
+  const nvmDir = env.NVM_DIR ?? (env.HOME ? join(env.HOME, '.nvm') : undefined)
+
+  if (!nvmDir) {
+    return []
+  }
+
+  try {
+    return readdirSync(join(nvmDir, 'versions', 'node'), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(nvmDir, 'versions', 'node', entry.name, 'bin', 'node'))
+      .sort()
+      .reverse()
+  } catch {
+    return []
+  }
+}
+
+const inspectNodeArchitecture = (
+  nodePath: string,
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined => {
+  const result = spawnSync(nodePath, ['-e', NODE_ARCH_SCRIPT], {
+    encoding: 'utf8',
+    env: {
+      ...env,
+      NODE_OPTIONS: '',
+    },
+    timeout: NODE_INSPECTION_TIMEOUT,
+  })
+
+  if (result.status !== 0) {
+    return undefined
+  }
+
+  return result.stdout.trim()
+}
+
+const createRosettaNodeFailureMessage = (): string =>
+  [
+    'Rosetta x64 Node detected on Apple Silicon.',
+    'Yarn PnP ESM commands can hang under this runtime.',
+    'Use native arm64 Node.js or set ATLS_YARN_NATIVE_NODE to its node binary.',
+    `Set ${ALLOW_ROSETTA_NODE}=true to bypass this guard explicitly.`,
+  ].join('\n')
+
+export const hasPnpLoaders = (nodeOptions: string = ''): boolean =>
+  nodeOptions.includes(PNP_CJS_LOADER) && nodeOptions.includes(PNP_ESM_LOADER)
+
+export const isYarnPnpRegularRuntime = (env: NodeJS.ProcessEnv = process.env): boolean =>
+  hasPnpLoaders(env.NODE_OPTIONS ?? '') || env[COMMAND_PROXY_EXECUTION] === 'true'
+
+export const isRosettaRuntime = (runtime: RuntimeState): boolean =>
+  runtime.platform === 'darwin' && runtime.arch === 'x64' && runtime.translated
+
+export const detectRosettaTranslation = (): boolean => {
+  if (process.platform !== 'darwin' || process.arch !== 'x64') {
+    return false
+  }
+
+  const result = spawnSync('sysctl', ['-in', ROSETTA_SYSCTL_KEY], {
+    encoding: 'utf8',
+    timeout: NODE_INSPECTION_TIMEOUT,
+  })
+
+  return result.status === 0 && result.stdout.trim() === '1'
+}
+
+export const detectRuntimeState = (): RuntimeState => ({
+  platform: process.platform,
+  arch: process.arch,
+  translated: detectRosettaTranslation(),
+})
+
+export const getNativeNodeCandidates = (
+  env: NodeJS.ProcessEnv = process.env,
+  execPath: string = process.execPath
+): Array<string> => {
+  const resolvedExecPath = resolve(execPath)
+
+  const candidates: Array<string | undefined> = [
+    env[NATIVE_NODE_PATH],
+    env.NVM_BIN ? join(env.NVM_BIN, 'node') : undefined,
+    ...getNvmNodeCandidates(env),
+    env.VOLTA_HOME ? join(env.VOLTA_HOME, 'bin', 'node') : undefined,
+    env.HOMEBREW_PREFIX ? join(env.HOMEBREW_PREFIX, 'bin', 'node') : undefined,
+    ...getPathNodeCandidates(env.PATH),
+    '/opt/homebrew/bin/node',
+    '/usr/local/bin/node',
+  ]
+
+  return Array.from(
+    new Set(
+      candidates
+        .filter((candidate): candidate is string => Boolean(candidate))
+        .map((candidate) => resolve(candidate))
+        .filter((candidate) => candidate !== resolvedExecPath)
+    )
+  )
+}
+
+export const resolveNativeArm64NodePath = ({
+  env = process.env,
+  execPath = process.execPath,
+  inspectNodeArchitecture: inspect = inspectNodeArchitecture,
+}: NativeNodeResolutionOptions = {}): string | undefined =>
+  getNativeNodeCandidates(env, execPath).find((candidate) => inspect(candidate, env) === 'arm64')
+
+export const reexecuteYarnWithNativeNodeIfNeeded = ({
+  cwd,
+  stderr,
+}: YarnPnpNativeNodeOptions): number | undefined => {
+  if (process.env[ALLOW_ROSETTA_NODE] === 'true') {
+    return undefined
+  }
+
+  if (!isRosettaRuntime(detectRuntimeState())) {
+    return undefined
+  }
+
+  if (process.env[NATIVE_NODE_REEXECUTION] === 'true') {
+    stderr.write(`${createRosettaNodeFailureMessage()}\n`)
+
+    return 1
+  }
+
+  const nodePath = resolveNativeArm64NodePath()
+
+  if (!nodePath) {
+    stderr.write(`${createRosettaNodeFailureMessage()}\n`)
+
+    return 1
+  }
+
+  stderr.write(`Rosetta x64 Node detected; re-running with native arm64 Node: ${nodePath}\n`)
+
+  const result = spawnSync(nodePath, process.argv.slice(1), {
+    cwd,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      [NATIVE_NODE_REEXECUTION]: 'true',
+    },
+  })
+
+  if (result.error) {
+    stderr.write(`${result.error.message}\n`)
+
+    return 1
+  }
+
+  return result.status ?? 1
+}
+
+export const executeYarnPnpProxy = async ({
+  cwd,
+  stderr,
+  executeRegular,
+  executeProxy,
+}: YarnPnpProxyOptions): Promise<number> => {
+  const nativeNodeExitCode = reexecuteYarnWithNativeNodeIfNeeded({ cwd, stderr })
+
+  if (typeof nativeNodeExitCode === 'number') {
+    return nativeNodeExitCode
+  }
+
+  if (isYarnPnpRegularRuntime()) {
+    return executeRegular()
+  }
+
+  return executeProxy()
+}
+
+export const pipeYarnPnpProxy = async ({
+  args,
+  cwd,
+  stdin,
+  stdout,
+  stderr,
+  env,
+}: YarnPnpProxyPipeOptions): Promise<number> => {
+  const yarnEntrypoint = process.argv[1]
+
+  const { code } = yarnEntrypoint
+    ? await execUtils.pipevp(process.execPath, [yarnEntrypoint, ...args], {
+        cwd,
+        stdin,
+        stdout,
+        stderr,
+        env,
+      })
+    : await execUtils.pipevp('yarn', args, {
+        cwd,
+        stdin,
+        stdout,
+        stderr,
+        env,
+      })
+
+  return code
+}


### PR DESCRIPTION
## Таска
- Close atls/raijin#619

Связанный хвост: atls/raijin#620 вынесен саб-таской к #619 для `js-yaml` PnP error в сборке CLI.

## Как проверять
### До фикса
1. Контекст: Apple Silicon, первым в `PATH` стоит Rosetta x64 Node из `/usr/local/bin/node`.
Действие: запустить `env PATH="/usr/local/bin:/Users/torinasakura/.nvm/versions/node/v24.11.1/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" /usr/local/bin/node .yarn/releases/yarn.mjs workspace @atls/code-service build`.
Ожидаемый результат: команда может зависать или падать на PnP ESM/runtime bootstrap.

### После фикса
1. Контекст: тот же Rosetta x64 Node как entrypoint.
Действие: запустить `env PATH="/usr/local/bin:/Users/torinasakura/.nvm/versions/node/v24.11.1/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" /usr/local/bin/node .yarn/releases/yarn.mjs workspace @atls/code-service build`.
Ожидаемый результат: CLI печатает handoff `Rosetta x64 Node detected; re-running with native arm64 Node: ...` и команда завершается с кодом `0`.

2. Контекст: Rosetta x64 Node как entrypoint.
Действие: запустить `/usr/local/bin/node .yarn/releases/yarn.mjs --version`.
Ожидаемый результат: CLI переисполняется через native arm64 Node и печатает `1.1.66-atls`.

## Пруфы
- `Rosetta service build` raw command
```bash
env PATH="/usr/local/bin:/Users/torinasakura/.nvm/versions/node/v24.11.1/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" /usr/local/bin/node .yarn/releases/yarn.mjs workspace @atls/code-service build
```

- `Rosetta service build` raw response
```text
Rosetta x64 Node detected; re-running with native arm64 Node: /Users/torinasakura/.nvm/versions/node/v24.11.1/bin/node
exit code: 0
```

- `Rosetta version` raw command
```bash
/usr/local/bin/node .yarn/releases/yarn.mjs --version
```

- `Rosetta version` raw response
```text
Rosetta x64 Node detected; re-running with native arm64 Node: /Users/torinasakura/.nvm/versions/node/v24.11.1/bin/node
1.1.66-atls
```

- `targeted lint` raw command
```bash
/Users/torinasakura/.nvm/versions/node/v24.11.1/bin/node .yarn/releases/yarn.mjs lint yarn/run-utils/sources/yarn-pnp-proxy.ts yarn/run-utils/sources/yarn-pnp-proxy.test.js yarn/plugin-checks/sources/proxy-corepack-env.guard.test.js
```

- `targeted lint` raw response
```text
0 Warnings 0 Errors
exit code: 0
```

- `unit smoke` raw command
```bash
/Users/torinasakura/.nvm/versions/node/v24.11.1/bin/node .yarn/releases/yarn.mjs node --loader @atls/code-runtime/ts-node-register --loader ./.pnp.loader.mjs --loader @atls/code-runtime/ts-ext-register --test yarn/run-utils/sources/yarn-pnp-proxy.test.js yarn/plugin-checks/sources/proxy-corepack-env.guard.test.js
```

- `unit smoke` raw response
```text
pass 5
fail 0
exit code: 0
```

- `targeted typecheck` raw command
```bash
/Users/torinasakura/.nvm/versions/node/v24.11.1/bin/node .yarn/releases/yarn.mjs typecheck yarn/run-utils/sources/yarn-pnp-proxy.ts yarn/cli/src/cli.ts yarn/plugin-service/sources/service-build.command.tsx yarn/plugin-service/sources/service-dev.command.tsx
```

- `targeted typecheck` raw response
```text
exit code: 0
```

- `CLI build` raw command
```bash
/Users/torinasakura/.nvm/versions/node/v24.11.1/bin/node .yarn/releases/yarn.mjs workspace @atls/yarn-cli build
```

- `CLI build` raw response
```text
Done building the CLI
Bundle version: 1.1.66-atls
exit code: 0
```

- `pre-commit` raw response
```text
lint-staged format: completed
lint-staged lint: completed
lint-staged typecheck: completed
commitlint: passed
```
