### PR TITLE
build: update image buildpacks

### DIFF
--- a/code/code-pack/src/pack.utils.ts
+++ b/code/code-pack/src/pack.utils.ts
@@ -13,6 +13,8 @@ interface InstallPackOptions {
 
 type InstallPack = (options: InstallPackOptions) => Promise<void>
 
+const PACK_VERSION = '0.40.4'
+
 /**
  * Installs pack if not present
  */
@@ -38,7 +40,7 @@ export const installPack: InstallPack = async ({ context, cwd }) => {
     // eslint-disable-next-line no-console
     console.log('Buildpack CLI (pack) is not installed. Installing it...')
 
-    let downloadUrl = 'https://github.com/buildpacks/pack/releases/download/v0.36.2/pack-v0.36.2-'
+    let downloadUrl = `https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/pack-v${PACK_VERSION}-`
 
     const currentPlatform = platform()
     const currentArch = arch()

--- a/runtime/code-runtime/src/schematic/templates/project/__dot__github/workflows/preview__dot__yaml
+++ b/runtime/code-runtime/src/schematic/templates/project/__dot__github/workflows/preview__dot__yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install Buildpack Cli
         run: |
-          (curl -sSL "https://github.com/buildpacks/pack/releases/download/v0.18.0/pack-v0.18.0-linux.tgz" | sudo tar -C /usr/local/bin/ --no-same-owner -xzv pack)
+          (curl -sSL "https://github.com/buildpacks/pack/releases/download/v0.40.4/pack-v0.40.4-linux.tgz" | sudo tar -C /usr/local/bin/ --no-same-owner -xzv pack)
 
       - name: Login to Google Container Registry
         run: echo -e $GCR_KEYFILE | docker login -u _json_key --password-stdin https://eu.gcr.io

--- a/runtime/code-runtime/src/schematic/templates/project/__dot__github/workflows/release__dot__yaml
+++ b/runtime/code-runtime/src/schematic/templates/project/__dot__github/workflows/release__dot__yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install Buildpack Cli
         run: |
-          (curl -sSL "https://github.com/buildpacks/pack/releases/download/v0.18.0/pack-v0.18.0-linux.tgz" | sudo tar -C /usr/local/bin/ --no-same-owner -xzv pack)
+          (curl -sSL "https://github.com/buildpacks/pack/releases/download/v0.40.4/pack-v0.40.4-linux.tgz" | sudo tar -C /usr/local/bin/ --no-same-owner -xzv pack)
       - name: Release
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/yarn/pack-utils/src/pack.utils.ts
+++ b/yarn/pack-utils/src/pack.utils.ts
@@ -1,3 +1,5 @@
+/// <reference path='./configuration-value-map.d.ts' />
+
 import type { Workspace }             from '@yarnpkg/core'
 import type { Report }                from '@yarnpkg/core'
 import type { PortablePath }          from '@yarnpkg/fslib'

--- a/yarn/plugin-image/sources/image-pack.command.ts
+++ b/yarn/plugin-image/sources/image-pack.command.ts
@@ -66,7 +66,7 @@ class ImagePackCommand extends BaseCommand {
         const content = readFileSync(join(this.context.cwd, 'package.json'), 'utf-8')
         const { packConfiguration = {} } = JSON.parse(content)
         const buildpackVersion = packConfiguration.buildpackVersion ?? '0.1.1'
-        const builderTag = packConfiguration.builderTag ?? '22'
+        const builderTag = packConfiguration.builderTag ?? '24'
         const { require } = packConfiguration
 
         await packUtils.pack(configuration, project, workspace, report, destination)


### PR DESCRIPTION
## Таска
- Close atls/raijin#639

## Как проверять
### Основной сценарий
1. Контекст: image pack для workspace с разрешённым build-скриптом
Действие: запустить image pack без publish
Ожидаемый результат: pack использует atlantislab/builder-base:24, atlantislab/buildpack-yarn-workspace:0.1.1 и успешно собирает локальный образ

### Дополнительный сценарий
1. Контекст: установка pack CLI из code-pack и workflow-шаблоны preview/release
Действие: проверить URL загрузки pack CLI
Ожидаемый результат: используется buildpacks/pack v0.40.4

## Пруфы
- Локальные проверки
```text
yarn workspace @atls/code-pack build
yarn workspace @atls/yarn-plugin-image build
yarn raijin:smoke:schematic
node yarn/cli/dist/yarn.mjs --version
git diff --check
```
- Интеграционный smoke image pack
```text
builder = "atlantislab/builder-base:24"
--buildpack atlantislab/buildpack-yarn-workspace:0.1.1
Successfully built image 'smoke-image-pack:89b3eb5-1778714785156'
```
