### PR TITLE
ci(github): guard publish chain after step failures

### DIFF
--- a/.github/actions/publish-npm/action.yml
+++ b/.github/actions/publish-npm/action.yml
@@ -1,4 +1,5 @@
 name: Publish composite action
+description: Publish changed packages to npm
 
 inputs:
   NPM_TOKEN:

--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -1,4 +1,5 @@
 name: Publish composite action
+description: Patch versions for changed packages before publish
 
 inputs:
   GITHUB_TOKEN:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,6 +26,7 @@ jobs:
     env:
       NODE_VERSION: '24'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions: write-all
 
     steps:
@@ -79,13 +80,14 @@ jobs:
           YARN_NPM_PUBLISH_REGISTRY: https://npm.pkg.github.com
 
       - name: Changelog
-        if: ${{ !cancelled() && github.event.pull_request.merged == true }}
+        if: ${{ success() && github.event.pull_request.merged == true }}
         uses: ./.github/actions/changelog
         with:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Publish to NPM
-        if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true) }}
+        if: ${{ success() && (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true) }}
+        timeout-minutes: 15
         id: npm
         uses: ./.github/actions/publish-npm
         with:
@@ -96,7 +98,8 @@ jobs:
           YARN_NPM_PUBLISH_REGISTRY: https://registry.npmjs.org
 
       - name: Publish to GitHub Packages
-        if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true) }}
+        if: ${{ success() && (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true) }}
+        timeout-minutes: 15
         id: github-packages
         uses: ./.github/actions/publish-github-packages
         with:
@@ -107,17 +110,17 @@ jobs:
           YARN_NPM_PUBLISH_REGISTRY: https://npm.pkg.github.com
 
       - name: Bundle yarn
-        if: ${{ !cancelled() && github.event.pull_request.merged == true }}
+        if: ${{ success() && github.event.pull_request.merged == true }}
         uses: ./.github/actions/bundle
 
       - name: Create release
-        if: ${{ !cancelled() && github.event.pull_request.merged == true }}
+        if: ${{ success() && github.event.pull_request.merged == true }}
         uses: ./.github/actions/release
         with:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Commit changes
-        if: ${{ !cancelled() && github.event.pull_request.merged == true }}
+        if: ${{ success() && github.event.pull_request.merged == true }}
         uses: ./.github/actions/commit
         with:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,7 +26,6 @@ jobs:
     env:
       NODE_VERSION: '24'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     permissions: write-all
 
     steps:
@@ -87,7 +86,6 @@ jobs:
 
       - name: Publish to NPM
         if: ${{ success() && (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true) }}
-        timeout-minutes: 15
         id: npm
         uses: ./.github/actions/publish-npm
         with:
@@ -99,7 +97,6 @@ jobs:
 
       - name: Publish to GitHub Packages
         if: ${{ success() && (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true) }}
-        timeout-minutes: 15
         id: github-packages
         uses: ./.github/actions/publish-github-packages
         with:


### PR DESCRIPTION
## Таска
- Close atls/raijin#650

## Как проверять
### До фикса
1. Контекст: Publish workflow после merge в master, где Publish to NPM завершается failure
Действие: Проверить условия следующих publish/release шагов
Ожидаемый результат: До фикса: следующие звенья цепи могут стартовать после failure, потому что завязаны на !cancelled()

### После фикса
1. Контекст: Publish workflow после merge в master, где любое звено publish/release chain завершается failure
Действие: Проверить условия следующих publish/release шагов
Ожидаемый результат: После фикса: следующие звенья цепи пропускаются через success() и не стартуют после failed step

## Пруфы
- .github/workflows/publish.yaml / .github/actions/version/action.yml / .github/actions/publish-npm/action.yml
```bash
node .yarn/releases/yarn.mjs format .github/workflows/publish.yaml .github/actions/version/action.yml .github/actions/publish-npm/action.yml
git diff --check
ruby -e "require 'yaml'; %w[.github/workflows/publish.yaml .github/actions/version/action.yml .github/actions/publish-npm/action.yml].each { |path| YAML.load_file(path) }; puts 'yaml ok'"
actionlint .github/workflows/publish.yaml
```