### PR TITLE
docs(release): document publish dispatch

### DIFF
--- a/docs/publish-dispatch.md
+++ b/docs/publish-dispatch.md
@@ -1,0 +1,10 @@
+# Publish Dispatch
+
+Raijin package releases are produced by the `Publish` workflow after a pull
+request is merged into `master`.
+
+Manual `workflow_dispatch` runs are reserved for registry access checks or a
+targeted workspace publish. A repository-wide release chain still requires a
+merged pull request outside `.github/**`, because the version, changelog,
+bundle, release, and follow-up commit steps are gated by the merged pull
+request event.


### PR DESCRIPTION
## Таска
- Close atls/raijin#652

## Как проверять
### До фикса
1. Контекст: Publish workflow после ручного запуска
Действие: открыть workflow_dispatch run на master
Ожидаемый результат: До фикса: ручной запуск проверяет доступы и publish-steps, но не создаёт repository-wide release chain, потому что version/changelog/bundle/release/commit завязаны на merged pull request event

### После фикса
1. Контекст: Publish workflow после merge PR вне `.github/**`
Действие: вмержить PR в master
Ожидаемый результат: После фикса: pull_request closed event запускает штатный Publish workflow с version, changelog, registry publish, bundle, release и follow-up commit steps

## Пруфы
- `docs/publish-dispatch.md` описывает различие между manual dispatch и merged PR publish path
- `git diff --check` прошёл без замечаний
