### PR TITLE
fix(code-pack): propagate pack command failures

### DIFF
--- a/code/code-pack/src/pack.ts
+++ b/code/code-pack/src/pack.ts
@@ -4,10 +4,11 @@ import type { PackOutputs } from './pack.interfaces.js'
 import { readFileSync }     from 'node:fs'
 
 import { stringify }        from '@iarna/toml'
-import { execUtils }        from '@yarnpkg/core'
+import type { execUtils }   from '@yarnpkg/core'
 import { xfs }              from '@yarnpkg/fslib'
 import { ppath }            from '@yarnpkg/fslib'
 
+import { execOrThrow }      from './pack.utils.js'
 import { installPack }      from './pack.utils.js'
 import { getTag }           from './tag.utils.js'
 
@@ -102,22 +103,20 @@ export const pack = async (
 
   await installPack({ cwd, context })
 
-  await execUtils.pipevp('pack', ['config', 'experimental', 'true'], {
+  await execOrThrow('pack', ['config', 'experimental', 'true'], {
     cwd: cwd ?? context.cwd,
     env: process.env,
     stdin: context.stdin,
     stdout: context.stdout,
     stderr: context.stderr,
-    end: execUtils.EndStrategy.ErrorCode,
   })
 
-  await execUtils.pipevp('pack', args, {
+  await execOrThrow('pack', args, {
     cwd: cwd ?? context.cwd,
     env: process.env,
     stdin: context.stdin,
     stdout: context.stdout,
     stderr: context.stderr,
-    end: execUtils.EndStrategy.ErrorCode,
   })
 
   return {

--- a/code/code-pack/src/pack.utils.ts
+++ b/code/code-pack/src/pack.utils.ts
@@ -15,6 +15,21 @@ type InstallPack = (options: InstallPackOptions) => Promise<void>
 
 const PACK_VERSION = '0.40.4'
 
+export const execOrThrow = async (
+  command: string,
+  args: Array<string>,
+  options: Omit<execUtils.PipevpOptions, 'end'>
+): Promise<void> => {
+  const { code } = await execUtils.pipevp(command, args, {
+    ...options,
+    end: execUtils.EndStrategy.ErrorCode,
+  })
+
+  if (code !== 0) {
+    throw new Error(`Command "${[command, ...args].join(' ')}" failed with exit code ${code}`)
+  }
+}
+
 /**
  * Installs pack if not present
  */
@@ -22,13 +37,12 @@ export const installPack: InstallPack = async ({ context, cwd }) => {
   let isPackInstalled: boolean
 
   try {
-    await execUtils.pipevp('pack', ['--version'], {
+    await execOrThrow('pack', ['--version'], {
       cwd: cwd ?? context.cwd,
       env: process.env,
       stdin: context.stdin,
       stdout: context.stdout,
       stderr: context.stderr,
-      end: execUtils.EndStrategy.ErrorCode,
     })
 
     isPackInstalled = true
@@ -62,22 +76,20 @@ export const installPack: InstallPack = async ({ context, cwd }) => {
 
     const tempFile = `${cwd ?? context.cwd}/pack.tgz`
 
-    await execUtils.pipevp('curl', ['-sSL', '-o', tempFile, downloadUrl], {
+    await execOrThrow('curl', ['-sSL', '-o', tempFile, downloadUrl], {
       cwd: cwd ?? context.cwd,
       env: process.env,
       stdin: context.stdin,
       stdout: context.stdout,
       stderr: context.stderr,
-      end: execUtils.EndStrategy.ErrorCode,
     })
 
-    await execUtils.pipevp('tar', ['-C', '/usr/local/bin/', '--no-same-owner', '-xzv', tempFile], {
+    await execOrThrow('tar', ['-C', '/usr/local/bin/', '--no-same-owner', '-xzv', tempFile], {
       cwd: cwd ?? context.cwd,
       env: process.env,
       stdin: context.stdin,
       stdout: context.stdout,
       stderr: context.stderr,
-      end: execUtils.EndStrategy.ErrorCode,
     })
 
     // eslint-disable-next-line no-console

--- a/code/code-pack/unit/pack-utils.test.ts
+++ b/code/code-pack/unit/pack-utils.test.ts
@@ -1,0 +1,29 @@
+import assert                    from 'node:assert/strict'
+import test                      from 'node:test'
+
+import { execOrThrow }           from '../src/pack.utils.js'
+
+test('should resolve when command exits with zero code', async () => {
+  await assert.doesNotReject(
+    execOrThrow(process.execPath, ['-e', 'process.exit(0)'], {
+      cwd: process.cwd(),
+      env: process.env,
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    })
+  )
+})
+
+test('should reject when command exits with non-zero code', async () => {
+  await assert.rejects(
+    execOrThrow(process.execPath, ['-e', 'process.exit(17)'], {
+      cwd: process.cwd(),
+      env: process.env,
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    }),
+    /failed with exit code 17/
+  )
+})

--- a/code/code-pack/unit/pack-utils.test.ts
+++ b/code/code-pack/unit/pack-utils.test.ts
@@ -1,12 +1,16 @@
 import assert                    from 'node:assert/strict'
 import test                      from 'node:test'
 
+import { npath }                 from '@yarnpkg/fslib'
+
 import { execOrThrow }           from '../src/pack.utils.js'
+
+const cwd = npath.toPortablePath(process.cwd())
 
 test('should resolve when command exits with zero code', async () => {
   await assert.doesNotReject(
     execOrThrow(process.execPath, ['-e', 'process.exit(0)'], {
-      cwd: process.cwd(),
+      cwd,
       env: process.env,
       stdin: process.stdin,
       stdout: process.stdout,
@@ -18,7 +22,7 @@ test('should resolve when command exits with zero code', async () => {
 test('should reject when command exits with non-zero code', async () => {
   await assert.rejects(
     execOrThrow(process.execPath, ['-e', 'process.exit(17)'], {
-      cwd: process.cwd(),
+      cwd,
       env: process.env,
       stdin: process.stdin,
       stdout: process.stdout,


### PR DESCRIPTION
## Task
- Close atls/raijin#701

## How To Verify
### Before Fix
1. Context: job/infrastructure command `yarn image pack`, where `@atls/code-pack` runs `pack build` through `execUtils.pipevp` with `EndStrategy.ErrorCode`.
Action: `pack build` returns a non-zero exit code after a CNB detection/build failure.
Expected result: `@atls/code-pack` does not throw, the `image pack` command `StreamReport` can finish with a successful exit code, and the caller has to inspect logs.

### After Fix
1. Context: job/infrastructure command `yarn image pack`, where `@atls/code-pack` runs `pack config`, `pack build`, `curl`, or `tar`.
Action: a child command returns a non-zero exit code.
Expected result: `@atls/code-pack` throws an error with the exit code, and `image pack` returns failure to the caller without log-grep workarounds.

## Proofs
- `yarn test unit --test-reporter=tap` from `code/code-pack`: passed
- `yarn workspace @atls/code-pack build`: passed
- `yarn lint code/code-pack/src/pack.ts code/code-pack/src/pack.utils.ts code/code-pack/unit/pack-utils.test.ts`: passed
