### PR TITLE
chore(common): recover private release artifacts

### DIFF
--- a/.yarn/versions/4dec4609.yml
+++ b/.yarn/versions/4dec4609.yml
@@ -1,0 +1,3 @@
+releases:
+  "@atls/yarn-cli": patch
+  "@atls/yarn-plugin-release": patch


### PR DESCRIPTION
## Task
- Close atls/raijin#708

## How To Verify
### Before Fix
1. Context: publish run https://github.com/atls/raijin/actions/runs/27418711294 before atls/infrastructure#830 was applied.
Action: Inspect the release action command used by the run.
Expected result: private workspaces are skipped by `--no-private`, so private GitHub Release artifacts are missing.

### After Fix
1. Context: this PR on top of the Terraform-managed release action from atls/infrastructure#830.
Action: Merge the PR and let the Publish workflow run normally.
Expected result: `@atls/yarn-cli` and `@atls/yarn-plugin-release` get recovered version records, and release creation uses `yarn workspaces changed foreach -v --exclude . release create` without publishing private packages to public registries.

## Proofs
- current release action command
```bash
yarn workspaces changed foreach -v --exclude . release create
```
- `yarn version apply --all --dry-run`
```bash
➤ YN0000: @atls/yarn-cli@workspace:yarn/cli: Bumped to 1.1.83
➤ YN0000: @atls/yarn-plugin-release@workspace:yarn/plugin-release: Bumped to 1.0.10
➤ YN0000: Done with warnings in 0s 3ms
```
- `yarn release version defer --dry-run`
```bash
➤ YN0000: No released workspaces need deferred version records
➤ YN0000: Done in 0s 34ms
```
- `git diff --check` passed
