### PR TITLE
fix(yarn-pack-utils): include yarn release in image payload

### DIFF
--- a/yarn/pack-utils/src/pack.utils.ts
+++ b/yarn/pack-utils/src/pack.utils.ts
@@ -16,6 +16,7 @@ import { packUtils }                  from '@yarnpkg/plugin-pack'
 
 import { ExportCache }                from './export/ExportCache.js'
 import { copyRcFile }                 from './copy.utils.js'
+import { copyYarnRelease }            from './copy.utils.js'
 import { genPackTgz }                 from './export/exportUtils.js'
 import { makeFetcher }                from './export/exportUtils.js'
 import { makeResolver }               from './export/exportUtils.js'
@@ -84,6 +85,10 @@ export const pack = async (
 
     await tgzUtils.extractArchiveTo(tgz, baseFs, { stripComponents: 1 })
     await copyRcFile(project, destination, report)
+
+    if (project.configuration.get('yarnPath')) {
+      await copyYarnRelease(project, destination, report)
+    }
 
     const tmpConfiguration = Configuration.create(destination, destination, configuration.plugins)
 


### PR DESCRIPTION
## Таска
- Close atls/raijin#706

## Как проверять
### До фикса
1. Контекст: Raijin `image pack` for a workspace whose source project has `.yarnrc.yml` `yarnPath: .yarn/releases/yarn-remote.mjs`.
Действие: inspect the generated image pack context.
Ожидаемый результат: `.yarn/releases/yarn-remote.mjs` is missing and generated `.yarnrc.yml` no longer contains `yarnPath`, so the runtime payload cannot execute package scripts with the same Yarn runtime that created the PnP payload.

### После фикса
1. Контекст: Raijin `image pack` for the same workspace.
Действие: inspect the generated image pack context.
Ожидаемый результат: the configured Yarn release is copied into `.yarn/releases`, and generated `.yarnrc.yml` keeps `yarnPath` because the release exists in the context.

## Пруфы
- `yarn workspace @atls/yarn-pack-utils test`
```text
passed
```
- `git diff --check`
```text
passed
```
- `yarn workspace @atls/yarn-pack-utils typecheck`
```text
failed on existing workspace-wide unrelated formatter/import typing errors outside yarn-pack-utils; staged pre-commit typecheck for yarn/pack-utils/src/pack.utils.ts passed
```
