### PR TITLE
chore(yarn-pack-utils): recover published metadata

### DIFF
--- a/yarn/pack-utils/CHANGELOG.md
+++ b/yarn/pack-utils/CHANGELOG.md
@@ -1,5 +1,17 @@
 
 
+## [1.0.8](https://github.com/atls/raijin/compare/@atls/yarn-pack-utils@1.0.7...@atls/yarn-pack-utils@1.0.8) (2026-06-15)
+
+
+### Bug Fixes
+
+
+* **yarn-pack-utils:** include yarn release in image payload ([169fb3d](https://github.com/atls/raijin/commit/169fb3d5585d6857b2eeed82a576b3e2a5ceb3ff))
+
+
+
+
+
 ## [1.0.7](https://github.com/atls/raijin/compare/@atls/yarn-pack-utils@1.0.6...@atls/yarn-pack-utils@1.0.7) (2026-06-15)
 
 
@@ -119,5 +131,4 @@
 
 
 * yarn pack utils deps ([5f775ab](https://github.com/atls/raijin/commit/5f775ab4413bb3a2f29f29fe667004323710109a))
-
 

--- a/yarn/pack-utils/package.json
+++ b/yarn/pack-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atls/yarn-pack-utils",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "license": "BSD-3-Clause",
   "type": "module",


### PR DESCRIPTION
## Таска
- Close atls/raijin#706

## Как проверять
### До фикса
1. Контекст: Raijin publish after `atls/raijin#734`
Действие: Compare registry/release state with `master` metadata for `@atls/yarn-pack-utils`.
Ожидаемый результат: До фикса: `@atls/yarn-pack-utils@1.0.8` is published, but `yarn/pack-utils/package.json` and `yarn/pack-utils/CHANGELOG.md` on `master` still point to `1.0.7` because the publish workflow failed at the commit step with a transient `502 Bad Gateway`.

### После фикса
1. Контекст: Raijin repository metadata
Действие: Read `yarn/pack-utils/package.json` and `yarn/pack-utils/CHANGELOG.md`.
Ожидаемый результат: После фикса: package metadata records the already-published `@atls/yarn-pack-utils@1.0.8` release without rerunning publish or changing package code.

## Пруфы
- `git diff --check`
```text
passed
```
- `yarn install --immutable`
```text
Done with warnings
```
- `yarn workspace @atls/yarn-pack-utils test`
```text
passed
```
