### PR TITLE
Fix release plan target resolution

### DIFF
--- a/yarn/plugin-release/sources/release-plan-create.command.ts
+++ b/yarn/plugin-release/sources/release-plan-create.command.ts
@@ -32,7 +32,7 @@ export class ReleasePlanCreateCommand extends BaseCommand {
 
     if (!workspace) throw new WorkspaceRequiredError(project.cwd, this.context.cwd)
 
-    const plan = await buildReleasePlan(project, this.since)
+    const plan = await buildReleasePlan(project, configuration, this.since)
     const content = `${JSON.stringify(plan, null, 2)}\n`
 
     if (!this.output) {

--- a/yarn/plugin-release/sources/release-plan-create.command.ts
+++ b/yarn/plugin-release/sources/release-plan-create.command.ts
@@ -18,6 +18,7 @@ export class ReleasePlanCreateCommand extends BaseCommand {
     details: `
       The release plan records the publish workspace selection and target package versions once,
       so later publish stages can consume the same state instead of recalculating changed workspaces.
+      Run it after yarn release version defer and before yarn version apply --all.
     `,
   })
 
@@ -31,7 +32,7 @@ export class ReleasePlanCreateCommand extends BaseCommand {
 
     if (!workspace) throw new WorkspaceRequiredError(project.cwd, this.context.cwd)
 
-    const plan = await buildReleasePlan(project, configuration, this.since)
+    const plan = await buildReleasePlan(project, this.since)
     const content = `${JSON.stringify(plan, null, 2)}\n`
 
     if (!this.output) {

--- a/yarn/plugin-release/sources/release-plan.utils.ts
+++ b/yarn/plugin-release/sources/release-plan.utils.ts
@@ -1,5 +1,7 @@
 import type { Workspace }                           from '@yarnpkg/core'
+import type { Configuration }                       from '@yarnpkg/core'
 import type { Project }                             from '@yarnpkg/core'
+import type { Filename }                            from '@yarnpkg/fslib'
 import type { PortablePath }                        from '@yarnpkg/fslib'
 
 import type { ReleaseVersionChange }                from './release-version-policy.utils.js'
@@ -10,10 +12,13 @@ import type { ReleaseVersionWorkspaceStrategy }     from './release-version-poli
 import { execUtils }                                from '@yarnpkg/core'
 import { structUtils }                              from '@yarnpkg/core'
 import { ppath }                                    from '@yarnpkg/fslib'
+import { xfs }                                      from '@yarnpkg/fslib'
+import { parseSyml }                                from '@yarnpkg/parsers'
 import { versionUtils }                             from '@yarnpkg/plugin-version'
 
 import { getChangedCommmits }                       from '@atls/yarn-plugin-files'
 
+import { mergeReleaseVersionDeferredDecision }      from './release-version-policy.utils.js'
 import { resolveReleaseVersionWorkspaceStrategies } from './release-version-policy.utils.js'
 
 type GitHubCommit = Awaited<ReturnType<typeof getChangedCommmits>>[number]
@@ -45,6 +50,14 @@ export interface ReleasePlanTarget {
 const DEFAULT_GIT_BASE_REF = 'origin/HEAD'
 const HEAD_REF = 'HEAD'
 const DEFAULT_GIT_RANGE = `${DEFAULT_GIT_BASE_REF}..${HEAD_REF}`
+const MISSING_DIRECTORY_ERROR_CODE = 'ENOENT'
+const DECLINE_DECISION = 'decline'
+
+const isErrorWithCode = (error: unknown, code: string): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as { code?: unknown }).code === code
 
 const toWorkspaceIdent = (
   workspace: Pick<ReleaseVersionWorkspaceCandidate, 'manifest'>
@@ -200,6 +213,70 @@ export const getReleaseVersionChanges = async (
   }
 
   return getLocalChanges(project, gitRange ?? DEFAULT_GIT_RANGE)
+}
+
+export const parseDeferredReleaseDecisions = (versionContent: string): Map<string, string> => {
+  const versionData = parseSyml(versionContent) as {
+    releases?: Record<string, unknown>
+    declined?: Array<unknown>
+  }
+  const decisions = new Map<string, string>()
+
+  for (const ident of versionData.declined ?? []) {
+    if (typeof ident !== 'string') {
+      continue
+    }
+
+    decisions.set(
+      ident,
+      mergeReleaseVersionDeferredDecision(decisions.get(ident), DECLINE_DECISION)
+    )
+  }
+
+  for (const [ident, decision] of Object.entries(versionData.releases ?? {})) {
+    if (typeof decision !== 'string') {
+      continue
+    }
+
+    decisions.set(ident, mergeReleaseVersionDeferredDecision(decisions.get(ident), decision))
+  }
+
+  return decisions
+}
+
+export const getDeferredReleaseDecisions = async (
+  configuration: Configuration
+): Promise<Map<string, string>> => {
+  const deferredVersionFolder = configuration.get('deferredVersionFolder')
+  const decisions = new Map<string, string>()
+  let entries: Array<Filename>
+
+  try {
+    entries = await xfs.readdirPromise(deferredVersionFolder)
+  } catch (error) {
+    if (isErrorWithCode(error, MISSING_DIRECTORY_ERROR_CODE)) {
+      return decisions
+    }
+
+    throw error
+  }
+
+  for (const entry of entries) {
+    if (!entry.endsWith('.yml')) {
+      continue
+    }
+
+    const versionPath = ppath.join(deferredVersionFolder, entry)
+    // eslint-disable-next-line no-await-in-loop
+    const versionContent = await xfs.readFilePromise(versionPath, 'utf8')
+    const versionDecisions = parseDeferredReleaseDecisions(versionContent)
+
+    for (const [ident, decision] of versionDecisions) {
+      decisions.set(ident, mergeReleaseVersionDeferredDecision(decisions.get(ident), decision))
+    }
+  }
+
+  return decisions
 }
 
 const toPlanWorkspace = (project: Project, target: ReleasePlanTarget): ReleasePlanWorkspace => {

--- a/yarn/plugin-release/sources/release-plan.utils.ts
+++ b/yarn/plugin-release/sources/release-plan.utils.ts
@@ -45,6 +45,7 @@ export interface ReleasePlan {
 export interface ReleasePlanTarget {
   workspace: ReleaseVersionWorkspace
   version: string
+  strategy: string
 }
 
 const DEFAULT_GIT_BASE_REF = 'origin/HEAD'
@@ -279,6 +280,18 @@ export const getDeferredReleaseDecisions = async (
   return decisions
 }
 
+export const getDeferredReleaseDeclinedIdents = async (
+  configuration: Configuration
+): Promise<Set<string>> => {
+  const decisions = await getDeferredReleaseDecisions(configuration)
+
+  return new Set(
+    [...decisions.entries()]
+      .filter(([, decision]) => decision === DECLINE_DECISION)
+      .map(([ident]) => ident)
+  )
+}
+
 const toPlanWorkspace = (project: Project, target: ReleasePlanTarget): ReleasePlanWorkspace => {
   const workspaceCwd = ppath.resolve(project.cwd, target.workspace.relativeCwd as PortablePath)
   const workspace = project.workspacesByCwd.get(workspaceCwd)
@@ -291,13 +304,49 @@ const toPlanWorkspace = (project: Project, target: ReleasePlanTarget): ReleasePl
     ident: target.workspace.ident,
     relativeCwd: target.workspace.relativeCwd,
     version: target.version,
-    strategy: target.version,
+    strategy: target.strategy,
     private: workspace.manifest.private,
   }
 }
 
+const toDeclinedReleasePlanTarget = (workspace: Workspace): ReleasePlanTarget | undefined => {
+  const releaseWorkspace = toReleaseWorkspace(workspace)
+  const { version } = workspace.manifest
+
+  if (!releaseWorkspace || !version) {
+    return undefined
+  }
+
+  return {
+    workspace: releaseWorkspace,
+    version,
+    strategy: DECLINE_DECISION,
+  }
+}
+
+const addDeclinedReleasePlanTargets = (
+  project: Project,
+  targets: Map<string, ReleasePlanTarget>,
+  declinedIdents: ReadonlySet<string>
+): void => {
+  for (const workspace of project.workspaces) {
+    const target = toDeclinedReleasePlanTarget(workspace)
+
+    if (
+      !target ||
+      !declinedIdents.has(target.workspace.ident) ||
+      targets.has(target.workspace.ident)
+    ) {
+      continue
+    }
+
+    targets.set(target.workspace.ident, target)
+  }
+}
+
 export const resolveReleasePlanTargets = async (
-  project: Project
+  project: Project,
+  declinedIdents: ReadonlySet<string> = new Set()
 ): Promise<Map<string, ReleasePlanTarget>> => {
   const versions = await versionUtils.resolveVersionFiles(project)
   const targets = new Map<string, ReleasePlanTarget>()
@@ -312,8 +361,11 @@ export const resolveReleasePlanTargets = async (
     targets.set(releaseWorkspace.ident, {
       workspace: releaseWorkspace,
       version,
+      strategy: version,
     })
   }
+
+  addDeclinedReleasePlanTargets(project, targets, declinedIdents)
 
   return targets
 }
@@ -354,11 +406,13 @@ export const resolveReleasePlanStrategies = (
 
 export const buildReleasePlan = async (
   project: Project,
+  configuration: Configuration,
   gitRange?: string
 ): Promise<ReleasePlan> => {
   const changes = await getReleaseVersionChanges(project, gitRange)
   const strategies = resolveReleasePlanStrategies(project, changes)
-  const targets = await resolveReleasePlanTargets(project)
+  const declinedIdents = await getDeferredReleaseDeclinedIdents(configuration)
+  const targets = await resolveReleasePlanTargets(project, declinedIdents)
 
   return createReleasePlan(project, strategies, targets)
 }

--- a/yarn/plugin-release/sources/release-plan.utils.ts
+++ b/yarn/plugin-release/sources/release-plan.utils.ts
@@ -1,7 +1,5 @@
 import type { Workspace }                           from '@yarnpkg/core'
-import type { Configuration }                       from '@yarnpkg/core'
 import type { Project }                             from '@yarnpkg/core'
-import type { Filename }                            from '@yarnpkg/fslib'
 import type { PortablePath }                        from '@yarnpkg/fslib'
 
 import type { ReleaseVersionChange }                from './release-version-policy.utils.js'
@@ -12,14 +10,10 @@ import type { ReleaseVersionWorkspaceStrategy }     from './release-version-poli
 import { execUtils }                                from '@yarnpkg/core'
 import { structUtils }                              from '@yarnpkg/core'
 import { ppath }                                    from '@yarnpkg/fslib'
-import { xfs }                                      from '@yarnpkg/fslib'
-import { parseSyml }                                from '@yarnpkg/parsers'
 import { versionUtils }                             from '@yarnpkg/plugin-version'
 
 import { getChangedCommmits }                       from '@atls/yarn-plugin-files'
 
-import { mergeReleaseVersionDeferredDecision }      from './release-version-policy.utils.js'
-import { resolveReleaseVersionDeferredStrategy }    from './release-version-policy.utils.js'
 import { resolveReleaseVersionWorkspaceStrategies } from './release-version-policy.utils.js'
 
 type GitHubCommit = Awaited<ReturnType<typeof getChangedCommmits>>[number]
@@ -43,21 +37,14 @@ export interface ReleasePlan {
   workspaces: Array<ReleasePlanWorkspace>
 }
 
+export interface ReleasePlanTarget {
+  workspace: ReleaseVersionWorkspace
+  version: string
+}
+
 const DEFAULT_GIT_BASE_REF = 'origin/HEAD'
 const HEAD_REF = 'HEAD'
 const DEFAULT_GIT_RANGE = `${DEFAULT_GIT_BASE_REF}..${HEAD_REF}`
-const MISSING_DIRECTORY_ERROR_CODE = 'ENOENT'
-const DECLINE_DECISION = 'decline'
-const IGNORED_RELEASE_DECISIONS = new Set<string>([
-  versionUtils.Decision.DECLINE,
-  versionUtils.Decision.UNDECIDED,
-])
-
-const isErrorWithCode = (error: unknown, code: string): boolean =>
-  typeof error === 'object' &&
-  error !== null &&
-  'code' in error &&
-  (error as { code?: unknown }).code === code
 
 const toWorkspaceIdent = (
   workspace: Pick<ReleaseVersionWorkspaceCandidate, 'manifest'>
@@ -215,136 +202,66 @@ export const getReleaseVersionChanges = async (
   return getLocalChanges(project, gitRange ?? DEFAULT_GIT_RANGE)
 }
 
-export const parseDeferredReleaseDecisions = (versionContent: string): Map<string, string> => {
-  const versionData = parseSyml(versionContent) as {
-    releases?: Record<string, unknown>
-    declined?: Array<unknown>
-  }
-  const decisions = new Map<string, string>()
-
-  for (const ident of versionData.declined ?? []) {
-    if (typeof ident !== 'string') {
-      continue
-    }
-
-    decisions.set(
-      ident,
-      mergeReleaseVersionDeferredDecision(decisions.get(ident), DECLINE_DECISION)
-    )
-  }
-
-  for (const [ident, decision] of Object.entries(versionData.releases ?? {})) {
-    if (typeof decision !== 'string') {
-      continue
-    }
-
-    decisions.set(ident, mergeReleaseVersionDeferredDecision(decisions.get(ident), decision))
-  }
-
-  return decisions
-}
-
-export const getDeferredReleaseDecisions = async (
-  configuration: Configuration
-): Promise<Map<string, string>> => {
-  const deferredVersionFolder = configuration.get('deferredVersionFolder')
-  const decisions = new Map<string, string>()
-  let entries: Array<Filename>
-
-  try {
-    entries = await xfs.readdirPromise(deferredVersionFolder)
-  } catch (error) {
-    if (isErrorWithCode(error, MISSING_DIRECTORY_ERROR_CODE)) {
-      return decisions
-    }
-
-    throw error
-  }
-
-  for (const entry of entries) {
-    if (!entry.endsWith('.yml')) {
-      continue
-    }
-
-    const versionPath = ppath.join(deferredVersionFolder, entry)
-    // eslint-disable-next-line no-await-in-loop
-    const versionContent = await xfs.readFilePromise(versionPath, 'utf8')
-    const versionDecisions = parseDeferredReleaseDecisions(versionContent)
-
-    for (const [ident, decision] of versionDecisions) {
-      decisions.set(ident, mergeReleaseVersionDeferredDecision(decisions.get(ident), decision))
-    }
-  }
-
-  return decisions
-}
-
-const isReleaseVersionDecision = (strategy: string): boolean => {
-  try {
-    return (
-      Boolean(versionUtils.validateReleaseDecision(strategy)) &&
-      !IGNORED_RELEASE_DECISIONS.has(strategy)
-    )
-  } catch {
-    return false
-  }
-}
-
-const resolveReleasePlanBaseVersion = (workspace: Workspace): string | undefined => {
-  const { stableVersion } = workspace.manifest.raw
-
-  return typeof stableVersion === 'string'
-    ? stableVersion
-    : (workspace.manifest.version ?? undefined)
-}
-
-const resolveReleasePlanTargetVersion = (version: string, strategy: string): string => {
-  if (IGNORED_RELEASE_DECISIONS.has(strategy)) {
-    return version
-  }
-
-  if (!isReleaseVersionDecision(strategy)) {
-    throw new Error(`Unsupported release decision "${strategy}"`)
-  }
-
-  return versionUtils.applyStrategy(version, strategy)
-}
-
-const toPlanWorkspace = (
-  project: Project,
-  strategy: ReleaseVersionWorkspaceStrategy,
-  deferredDecisions: ReadonlyMap<string, string>
-): ReleasePlanWorkspace => {
-  const workspaceCwd = ppath.resolve(project.cwd, strategy.workspace.relativeCwd as PortablePath)
+const toPlanWorkspace = (project: Project, target: ReleasePlanTarget): ReleasePlanWorkspace => {
+  const workspaceCwd = ppath.resolve(project.cwd, target.workspace.relativeCwd as PortablePath)
   const workspace = project.workspacesByCwd.get(workspaceCwd)
-  const version = workspace ? resolveReleasePlanBaseVersion(workspace) : undefined
 
-  if (!workspace || !version) {
-    throw new Error(`Could not resolve release workspace "${strategy.workspace.ident}"`)
+  if (!workspace) {
+    throw new Error(`Could not resolve release workspace "${target.workspace.ident}"`)
   }
-
-  const effectiveStrategy = resolveReleaseVersionDeferredStrategy(
-    deferredDecisions.get(strategy.workspace.ident),
-    strategy.strategy
-  )
 
   return {
-    ident: strategy.workspace.ident,
-    relativeCwd: strategy.workspace.relativeCwd,
-    version: resolveReleasePlanTargetVersion(version, effectiveStrategy),
-    strategy: effectiveStrategy,
+    ident: target.workspace.ident,
+    relativeCwd: target.workspace.relativeCwd,
+    version: target.version,
+    strategy: target.version,
     private: workspace.manifest.private,
   }
+}
+
+export const resolveReleasePlanTargets = async (
+  project: Project
+): Promise<Map<string, ReleasePlanTarget>> => {
+  const versions = await versionUtils.resolveVersionFiles(project)
+  const targets = new Map<string, ReleasePlanTarget>()
+
+  for (const [workspace, version] of versions) {
+    const releaseWorkspace = toReleaseWorkspace(workspace)
+
+    if (!releaseWorkspace) {
+      continue
+    }
+
+    targets.set(releaseWorkspace.ident, {
+      workspace: releaseWorkspace,
+      version,
+    })
+  }
+
+  return targets
 }
 
 export const createReleasePlan = (
   project: Project,
   strategies: ReadonlyArray<ReleaseVersionWorkspaceStrategy>,
-  deferredDecisions: ReadonlyMap<string, string>
-): ReleasePlan => ({
-  schemaVersion: 1,
-  workspaces: strategies.map((strategy) => toPlanWorkspace(project, strategy, deferredDecisions)),
-})
+  targets: ReadonlyMap<string, ReleasePlanTarget>
+): ReleasePlan => {
+  for (const strategy of strategies) {
+    if (!targets.has(strategy.workspace.ident)) {
+      throw new Error(
+        `Release plan requires deferred target version for "${strategy.workspace.ident}". ` +
+          'Run `yarn release version defer` before `yarn release plan create`.'
+      )
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    workspaces: [...targets.values()]
+      .sort((left, right) => left.workspace.relativeCwd.localeCompare(right.workspace.relativeCwd))
+      .map((target) => toPlanWorkspace(project, target)),
+  }
+}
 
 export const resolveReleasePlanStrategies = (
   project: Project,
@@ -360,14 +277,13 @@ export const resolveReleasePlanStrategies = (
 
 export const buildReleasePlan = async (
   project: Project,
-  configuration: Configuration,
   gitRange?: string
 ): Promise<ReleasePlan> => {
   const changes = await getReleaseVersionChanges(project, gitRange)
   const strategies = resolveReleasePlanStrategies(project, changes)
-  const deferredDecisions = await getDeferredReleaseDecisions(configuration)
+  const targets = await resolveReleasePlanTargets(project)
 
-  return createReleasePlan(project, strategies, deferredDecisions)
+  return createReleasePlan(project, strategies, targets)
 }
 
 const isReleasePlanWorkspace = (workspace: unknown): workspace is ReleasePlanWorkspace => {

--- a/yarn/plugin-release/sources/release-version-defer.command.ts
+++ b/yarn/plugin-release/sources/release-version-defer.command.ts
@@ -1,17 +1,14 @@
-import { BaseCommand }                           from '@yarnpkg/cli'
-import { WorkspaceRequiredError }                from '@yarnpkg/cli'
-import { Configuration }                         from '@yarnpkg/core'
-import { Project }                               from '@yarnpkg/core'
-import { StreamReport }                          from '@yarnpkg/core'
-import { Option }                                from 'clipanion'
+import { BaseCommand }                  from '@yarnpkg/cli'
+import { WorkspaceRequiredError }       from '@yarnpkg/cli'
+import { Configuration }                from '@yarnpkg/core'
+import { Project }                      from '@yarnpkg/core'
+import { StreamReport }                 from '@yarnpkg/core'
+import { Option }                       from 'clipanion'
 
-import { getDeferredReleaseDecisions }           from './release-plan.utils.js'
-import { getReleaseVersionChanges }              from './release-plan.utils.js'
-import { resolveReleasePlanStrategies }          from './release-plan.utils.js'
-import { resolveReleaseVersionDeferredStrategy } from './release-version-policy.utils.js'
+import { getReleaseVersionChanges }     from './release-plan.utils.js'
+import { resolveReleasePlanStrategies } from './release-plan.utils.js'
 
 export { isReleaseVersionWorkspace } from './release-plan.utils.js'
-export { parseDeferredReleaseDecisions } from './release-plan.utils.js'
 export { selectLocalCommitDiffParent } from './release-plan.utils.js'
 export { toGitHubChange } from './release-plan.utils.js'
 
@@ -43,15 +40,8 @@ export class ReleaseVersionDeferCommand extends BaseCommand {
           return
         }
 
-        const deferredDecisions = await getDeferredReleaseDecisions(configuration)
-
         for (const { workspace: changedWorkspace, strategy } of strategies) {
-          const effectiveStrategy = resolveReleaseVersionDeferredStrategy(
-            deferredDecisions.get(changedWorkspace.ident),
-            strategy
-          )
-
-          report.reportInfo(null, `Deferring ${changedWorkspace.ident} as ${effectiveStrategy}`)
+          report.reportInfo(null, `Deferring ${changedWorkspace.ident} as ${strategy}`)
 
           if (this.dryRun) {
             continue
@@ -60,7 +50,7 @@ export class ReleaseVersionDeferCommand extends BaseCommand {
           // Deferred version records share the same `.yarn/versions` state.
           // eslint-disable-next-line no-await-in-loop
           const code = await this.cli.run(
-            ['workspace', changedWorkspace.ident, 'version', effectiveStrategy, '--deferred'],
+            ['workspace', changedWorkspace.ident, 'version', strategy, '--deferred'],
             {
               cwd: project.cwd,
             }

--- a/yarn/plugin-release/sources/release-version-defer.command.ts
+++ b/yarn/plugin-release/sources/release-version-defer.command.ts
@@ -1,14 +1,17 @@
-import { BaseCommand }                  from '@yarnpkg/cli'
-import { WorkspaceRequiredError }       from '@yarnpkg/cli'
-import { Configuration }                from '@yarnpkg/core'
-import { Project }                      from '@yarnpkg/core'
-import { StreamReport }                 from '@yarnpkg/core'
-import { Option }                       from 'clipanion'
+import { BaseCommand }                           from '@yarnpkg/cli'
+import { WorkspaceRequiredError }                from '@yarnpkg/cli'
+import { Configuration }                         from '@yarnpkg/core'
+import { Project }                               from '@yarnpkg/core'
+import { StreamReport }                          from '@yarnpkg/core'
+import { Option }                                from 'clipanion'
 
-import { getReleaseVersionChanges }     from './release-plan.utils.js'
-import { resolveReleasePlanStrategies } from './release-plan.utils.js'
+import { getDeferredReleaseDecisions }           from './release-plan.utils.js'
+import { getReleaseVersionChanges }              from './release-plan.utils.js'
+import { resolveReleasePlanStrategies }          from './release-plan.utils.js'
+import { resolveReleaseVersionDeferredStrategy } from './release-version-policy.utils.js'
 
 export { isReleaseVersionWorkspace } from './release-plan.utils.js'
+export { parseDeferredReleaseDecisions } from './release-plan.utils.js'
 export { selectLocalCommitDiffParent } from './release-plan.utils.js'
 export { toGitHubChange } from './release-plan.utils.js'
 
@@ -40,8 +43,15 @@ export class ReleaseVersionDeferCommand extends BaseCommand {
           return
         }
 
+        const deferredDecisions = await getDeferredReleaseDecisions(configuration)
+
         for (const { workspace: changedWorkspace, strategy } of strategies) {
-          report.reportInfo(null, `Deferring ${changedWorkspace.ident} as ${strategy}`)
+          const effectiveStrategy = resolveReleaseVersionDeferredStrategy(
+            deferredDecisions.get(changedWorkspace.ident),
+            strategy
+          )
+
+          report.reportInfo(null, `Deferring ${changedWorkspace.ident} as ${effectiveStrategy}`)
 
           if (this.dryRun) {
             continue
@@ -50,14 +60,14 @@ export class ReleaseVersionDeferCommand extends BaseCommand {
           // Deferred version records share the same `.yarn/versions` state.
           // eslint-disable-next-line no-await-in-loop
           const code = await this.cli.run(
-            ['workspace', changedWorkspace.ident, 'version', strategy, '--deferred'],
+            ['workspace', changedWorkspace.ident, 'version', effectiveStrategy, '--deferred'],
             {
               cwd: project.cwd,
             }
           )
 
           if (code > 0) {
-            throw new Error(`Failed to defer ${changedWorkspace.ident} as ${strategy}`)
+            throw new Error(`Failed to defer ${changedWorkspace.ident} as ${effectiveStrategy}`)
           }
         }
       }

--- a/yarn/plugin-release/sources/release-version-policy.utils.ts
+++ b/yarn/plugin-release/sources/release-version-policy.utils.ts
@@ -39,10 +39,47 @@ const STRATEGY_WEIGHT: Record<ReleaseVersionStrategy, number> = {
   major: 2,
 }
 
+const isReleaseVersionStrategy = (strategy: string): strategy is ReleaseVersionStrategy =>
+  Object.hasOwn(STRATEGY_WEIGHT, strategy)
+
 const compareStrategies = (
   current: ReleaseVersionStrategy,
   next: ReleaseVersionStrategy
 ): ReleaseVersionStrategy => (STRATEGY_WEIGHT[next] > STRATEGY_WEIGHT[current] ? next : current)
+
+export const resolveReleaseVersionDeferredStrategy = (
+  current: string | undefined,
+  next: ReleaseVersionStrategy
+): string => {
+  if (current === undefined) {
+    return next
+  }
+
+  if (!isReleaseVersionStrategy(current)) {
+    return current
+  }
+
+  return compareStrategies(current, next)
+}
+
+export const mergeReleaseVersionDeferredDecision = (
+  current: string | undefined,
+  next: string
+): string => {
+  if (current === undefined) {
+    return next
+  }
+
+  if (!isReleaseVersionStrategy(current)) {
+    return current
+  }
+
+  if (!isReleaseVersionStrategy(next)) {
+    return next
+  }
+
+  return resolveReleaseVersionDeferredStrategy(current, next)
+}
 
 const isRootWorkspace = (workspace: ReleaseVersionWorkspaceOwner): boolean =>
   workspace.relativeCwd === ROOT_WORKSPACE_CWD

--- a/yarn/plugin-release/sources/release-version-policy.utils.ts
+++ b/yarn/plugin-release/sources/release-version-policy.utils.ts
@@ -39,47 +39,10 @@ const STRATEGY_WEIGHT: Record<ReleaseVersionStrategy, number> = {
   major: 2,
 }
 
-const isReleaseVersionStrategy = (strategy: string): strategy is ReleaseVersionStrategy =>
-  Object.hasOwn(STRATEGY_WEIGHT, strategy)
-
 const compareStrategies = (
   current: ReleaseVersionStrategy,
   next: ReleaseVersionStrategy
 ): ReleaseVersionStrategy => (STRATEGY_WEIGHT[next] > STRATEGY_WEIGHT[current] ? next : current)
-
-export const resolveReleaseVersionDeferredStrategy = (
-  current: string | undefined,
-  next: ReleaseVersionStrategy
-): string => {
-  if (current === undefined) {
-    return next
-  }
-
-  if (!isReleaseVersionStrategy(current)) {
-    return current
-  }
-
-  return compareStrategies(current, next)
-}
-
-export const mergeReleaseVersionDeferredDecision = (
-  current: string | undefined,
-  next: string
-): string => {
-  if (current === undefined) {
-    return next
-  }
-
-  if (!isReleaseVersionStrategy(current)) {
-    return current
-  }
-
-  if (!isReleaseVersionStrategy(next)) {
-    return next
-  }
-
-  return resolveReleaseVersionDeferredStrategy(current, next)
-}
 
 const isRootWorkspace = (workspace: ReleaseVersionWorkspaceOwner): boolean =>
   workspace.relativeCwd === ROOT_WORKSPACE_CWD

--- a/yarn/plugin-release/sources/tests/release-plan.utils.test.ts
+++ b/yarn/plugin-release/sources/tests/release-plan.utils.test.ts
@@ -50,7 +50,11 @@ const createProject = (workspaces: Array<Workspace>): Project =>
     ),
   }) as Project
 
-const createTarget = (workspace: Workspace, version: string): ReleasePlanTarget => {
+const createTarget = (
+  workspace: Workspace,
+  version: string,
+  strategy: string = version
+): ReleasePlanTarget => {
   if (!workspace.manifest.name) {
     throw new Error('Release plan target test workspace must have an ident')
   }
@@ -61,6 +65,7 @@ const createTarget = (workspace: Workspace, version: string): ReleasePlanTarget 
       relativeCwd: workspace.relativeCwd,
     },
     version,
+    strategy,
   }
 }
 
@@ -227,6 +232,36 @@ test('should resolve release plan targets through Yarn version files', async (co
       ['@atls/code-runtime', createTarget(runtimeWorkspace, '2.2.0')],
       ['@atls/yarn-cli', createTarget(cliWorkspace, '1.2.0')],
     ]
+  )
+})
+
+test('should include declined deferred workspaces in release plan targets', async (context) => {
+  const project = createProject([rootWorkspace, runtimeWorkspace, cliWorkspace])
+
+  context.mock.method(versionUtils, 'resolveVersionFiles', async () => new Map())
+
+  const targets = await resolveReleasePlanTargets(project, new Set(['@atls/code-runtime']))
+
+  assert.deepEqual(
+    [...targets.entries()],
+    [['@atls/code-runtime', createTarget(runtimeWorkspace, '2.1.33', 'decline')]]
+  )
+})
+
+test('should prefer Yarn resolved targets over declined deferred fallbacks', async (context) => {
+  const project = createProject([rootWorkspace, runtimeWorkspace, cliWorkspace])
+
+  context.mock.method(
+    versionUtils,
+    'resolveVersionFiles',
+    async () => new Map([[runtimeWorkspace, '2.2.0']])
+  )
+
+  const targets = await resolveReleasePlanTargets(project, new Set(['@atls/code-runtime']))
+
+  assert.deepEqual(
+    [...targets.entries()],
+    [['@atls/code-runtime', createTarget(runtimeWorkspace, '2.2.0')]]
   )
 })
 

--- a/yarn/plugin-release/sources/tests/release-plan.utils.test.ts
+++ b/yarn/plugin-release/sources/tests/release-plan.utils.test.ts
@@ -2,15 +2,19 @@ import type { Project }                 from '@yarnpkg/core'
 import type { Workspace }               from '@yarnpkg/core'
 import type { PortablePath }            from '@yarnpkg/fslib'
 
+import type { ReleasePlanTarget }       from '../release-plan.utils.js'
+
 import assert                           from 'node:assert/strict'
 import { test }                         from 'node:test'
 
 import { structUtils }                  from '@yarnpkg/core'
 import { ppath }                        from '@yarnpkg/fslib'
+import { versionUtils }                 from '@yarnpkg/plugin-version'
 
 import { createReleasePlan }            from '../release-plan.utils.js'
 import { parseReleasePlan }             from '../release-plan.utils.js'
 import { resolveReleasePlanStrategies } from '../release-plan.utils.js'
+import { resolveReleasePlanTargets }    from '../release-plan.utils.js'
 
 const createWorkspace = (
   ident: string,
@@ -46,7 +50,21 @@ const createProject = (workspaces: Array<Workspace>): Project =>
     ),
   }) as Project
 
-test('should create a fixed release plan from selected workspace strategies', () => {
+const createTarget = (workspace: Workspace, version: string): ReleasePlanTarget => {
+  if (!workspace.manifest.name) {
+    throw new Error('Release plan target test workspace must have an ident')
+  }
+
+  return {
+    workspace: {
+      ident: structUtils.stringifyIdent(workspace.manifest.name),
+      relativeCwd: workspace.relativeCwd,
+    },
+    version,
+  }
+}
+
+test('should create a fixed release plan from Yarn deferred targets', () => {
   const project = createProject([rootWorkspace, runtimeWorkspace, cliWorkspace])
   const strategies = resolveReleasePlanStrategies(project, [
     {
@@ -58,8 +76,12 @@ test('should create a fixed release plan from selected workspace strategies', ()
       files: ['yarn/cli/sources/index.ts'],
     },
   ])
+  const targets = new Map([
+    ['@atls/code-runtime', createTarget(runtimeWorkspace, '3.0.0')],
+    ['@atls/yarn-cli', createTarget(cliWorkspace, '1.1.97')],
+  ])
 
-  const plan = createReleasePlan(project, strategies, new Map([['@atls/code-runtime', 'major']]))
+  const plan = createReleasePlan(project, strategies, targets)
 
   assert.deepEqual(plan, {
     schemaVersion: 1,
@@ -68,21 +90,57 @@ test('should create a fixed release plan from selected workspace strategies', ()
         ident: '@atls/code-runtime',
         relativeCwd: 'runtime/code-runtime',
         version: '3.0.0',
-        strategy: 'major',
+        strategy: '3.0.0',
         private: false,
       },
       {
         ident: '@atls/yarn-cli',
         relativeCwd: 'yarn/cli',
         version: '1.1.97',
-        strategy: 'patch',
+        strategy: '1.1.97',
         private: true,
       },
     ],
   })
 })
 
-test('should write target minor versions into release plan', () => {
+test('should include deferred-only workspaces in release plan', () => {
+  const project = createProject([rootWorkspace, runtimeWorkspace, cliWorkspace])
+  const strategies = [
+    {
+      workspace: {
+        ident: '@atls/code-runtime',
+        relativeCwd: 'runtime/code-runtime',
+      },
+      strategy: 'patch',
+    } as const,
+  ]
+  const targets = new Map([
+    ['@atls/code-runtime', createTarget(runtimeWorkspace, '2.1.34')],
+    ['@atls/yarn-cli', createTarget(cliWorkspace, '1.1.97')],
+  ])
+
+  const plan = createReleasePlan(project, strategies, targets)
+
+  assert.deepEqual(plan.workspaces, [
+    {
+      ident: '@atls/code-runtime',
+      relativeCwd: 'runtime/code-runtime',
+      version: '2.1.34',
+      strategy: '2.1.34',
+      private: false,
+    },
+    {
+      ident: '@atls/yarn-cli',
+      relativeCwd: 'yarn/cli',
+      version: '1.1.97',
+      strategy: '1.1.97',
+      private: true,
+    },
+  ])
+})
+
+test('should require deferred target versions for changed workspaces', () => {
   const project = createProject([rootWorkspace, runtimeWorkspace])
   const strategies = [
     {
@@ -94,20 +152,34 @@ test('should write target minor versions into release plan', () => {
     } as const,
   ]
 
-  const plan = createReleasePlan(project, strategies, new Map([['@atls/code-runtime', 'minor']]))
-
-  assert.deepEqual(plan.workspaces, [
-    {
-      ident: '@atls/code-runtime',
-      relativeCwd: 'runtime/code-runtime',
-      version: '2.2.0',
-      strategy: 'minor',
-      private: false,
-    },
-  ])
+  assert.throws(() => createReleasePlan(project, strategies, new Map()), {
+    message:
+      'Release plan requires deferred target version for "@atls/code-runtime". ' +
+      'Run `yarn release version defer` before `yarn release plan create`.',
+  })
 })
 
-test('should write exact deferred versions into release plan', () => {
+test('should not bump already applied manifest versions without deferred targets', () => {
+  const appliedWorkspace = createWorkspace('@atls/code-runtime', 'runtime/code-runtime', '2.2.0')
+  const project = createProject([rootWorkspace, appliedWorkspace])
+  const strategies = [
+    {
+      workspace: {
+        ident: '@atls/code-runtime',
+        relativeCwd: 'runtime/code-runtime',
+      },
+      strategy: 'minor',
+    } as const,
+  ]
+
+  assert.throws(() => createReleasePlan(project, strategies, new Map()), {
+    message:
+      'Release plan requires deferred target version for "@atls/code-runtime". ' +
+      'Run `yarn release version defer` before `yarn release plan create`.',
+  })
+})
+
+test('should preserve exact Yarn deferred targets in release plan', () => {
   const project = createProject([rootWorkspace, cliWorkspace])
   const strategies = [
     {
@@ -118,8 +190,9 @@ test('should write exact deferred versions into release plan', () => {
       strategy: 'patch',
     } as const,
   ]
+  const targets = new Map([['@atls/yarn-cli', createTarget(cliWorkspace, '1.5.0')]])
 
-  const plan = createReleasePlan(project, strategies, new Map([['@atls/yarn-cli', '1.5.0']]))
+  const plan = createReleasePlan(project, strategies, targets)
 
   assert.deepEqual(plan.workspaces, [
     {
@@ -132,106 +205,29 @@ test('should write exact deferred versions into release plan', () => {
   ])
 })
 
-test('should reject unsupported deferred version ranges in release plan', () => {
-  const project = createProject([rootWorkspace, cliWorkspace])
-  const strategies = [
-    {
-      workspace: {
-        ident: '@atls/yarn-cli',
-        relativeCwd: 'yarn/cli',
-      },
-      strategy: 'patch',
-    } as const,
-  ]
+test('should resolve release plan targets through Yarn version files', async (context) => {
+  const project = createProject([rootWorkspace, runtimeWorkspace, cliWorkspace])
 
-  assert.throws(
-    () => createReleasePlan(project, strategies, new Map([['@atls/yarn-cli', '^2.0.0']])),
-    {
-      message: 'Unsupported release decision "^2.0.0"',
-    }
+  context.mock.method(
+    versionUtils,
+    'resolveVersionFiles',
+    async () =>
+      new Map([
+        [runtimeWorkspace, '2.2.0'],
+        [rootWorkspace, '1.0.1'],
+        [cliWorkspace, '1.2.0'],
+      ])
   )
-})
 
-test('should match Yarn patch target for prerelease workspaces', () => {
-  const prereleaseWorkspace = createWorkspace(
-    '@atls/code-runtime',
-    'runtime/code-runtime',
-    '2.1.33-alpha.0',
-    false,
-    {
-      stableVersion: '2.1.32',
-    }
+  const targets = await resolveReleasePlanTargets(project)
+
+  assert.deepEqual(
+    [...targets.entries()],
+    [
+      ['@atls/code-runtime', createTarget(runtimeWorkspace, '2.2.0')],
+      ['@atls/yarn-cli', createTarget(cliWorkspace, '1.2.0')],
+    ]
   )
-  const project = createProject([rootWorkspace, prereleaseWorkspace])
-  const strategies = [
-    {
-      workspace: {
-        ident: '@atls/code-runtime',
-        relativeCwd: 'runtime/code-runtime',
-      },
-      strategy: 'patch',
-    } as const,
-  ]
-
-  const plan = createReleasePlan(project, strategies, new Map())
-
-  assert.deepEqual(plan.workspaces, [
-    {
-      ident: '@atls/code-runtime',
-      relativeCwd: 'runtime/code-runtime',
-      version: '2.1.33',
-      strategy: 'patch',
-      private: false,
-    },
-  ])
-})
-
-test('should write prerelease strategy target versions into release plan', () => {
-  const prereleaseWorkspace = createWorkspace(
-    '@atls/code-runtime',
-    'runtime/code-runtime',
-    '2.1.33-alpha.0'
-  )
-  const project = createProject([rootWorkspace, prereleaseWorkspace, cliWorkspace])
-  const strategies = [
-    {
-      workspace: {
-        ident: '@atls/code-runtime',
-        relativeCwd: 'runtime/code-runtime',
-      },
-      strategy: 'patch',
-    } as const,
-    {
-      workspace: {
-        ident: '@atls/yarn-cli',
-        relativeCwd: 'yarn/cli',
-      },
-      strategy: 'patch',
-    } as const,
-  ]
-  const deferredDecisions = new Map([
-    ['@atls/code-runtime', 'prerelease'],
-    ['@atls/yarn-cli', 'preminor'],
-  ])
-
-  const plan = createReleasePlan(project, strategies, deferredDecisions)
-
-  assert.deepEqual(plan.workspaces, [
-    {
-      ident: '@atls/code-runtime',
-      relativeCwd: 'runtime/code-runtime',
-      version: '2.1.33-alpha.1',
-      strategy: 'prerelease',
-      private: false,
-    },
-    {
-      ident: '@atls/yarn-cli',
-      relativeCwd: 'yarn/cli',
-      version: '1.2.0-0',
-      strategy: 'preminor',
-      private: true,
-    },
-  ])
 })
 
 test('should reject malformed release plan content', () => {

--- a/yarn/plugin-release/sources/tests/release-version-defer.command.test.ts
+++ b/yarn/plugin-release/sources/tests/release-version-defer.command.test.ts
@@ -1,11 +1,12 @@
-import assert                          from 'node:assert/strict'
-import { test }                        from 'node:test'
+import assert                            from 'node:assert/strict'
+import { test }                          from 'node:test'
 
-import { structUtils }                 from '@yarnpkg/core'
+import { structUtils }                   from '@yarnpkg/core'
 
-import { isReleaseVersionWorkspace }   from '../release-version-defer.command.js'
-import { selectLocalCommitDiffParent } from '../release-version-defer.command.js'
-import { toGitHubChange }              from '../release-version-defer.command.js'
+import { isReleaseVersionWorkspace }     from '../release-version-defer.command.js'
+import { parseDeferredReleaseDecisions } from '../release-version-defer.command.js'
+import { selectLocalCommitDiffParent }   from '../release-version-defer.command.js'
+import { toGitHubChange }                from '../release-version-defer.command.js'
 
 test('should include previous GitHub filenames for renamed files', () => {
   const change = toGitHubChange({
@@ -58,6 +59,23 @@ test('should include private versioned workspaces in release version policy', ()
       },
     }),
     true
+  )
+})
+
+test('should parse deferred release decisions', () => {
+  assert.deepEqual(
+    parseDeferredReleaseDecisions(`
+releases:
+  "@atls/code-runtime": minor
+  "@atls/yarn-cli": 1.2.0
+declined:
+  - "@atls/code-test"
+`),
+    new Map([
+      ['@atls/code-test', 'decline'],
+      ['@atls/code-runtime', 'minor'],
+      ['@atls/yarn-cli', '1.2.0'],
+    ])
   )
 })
 

--- a/yarn/plugin-release/sources/tests/release-version-defer.command.test.ts
+++ b/yarn/plugin-release/sources/tests/release-version-defer.command.test.ts
@@ -1,12 +1,11 @@
-import assert                            from 'node:assert/strict'
-import { test }                          from 'node:test'
+import assert                          from 'node:assert/strict'
+import { test }                        from 'node:test'
 
-import { structUtils }                   from '@yarnpkg/core'
+import { structUtils }                 from '@yarnpkg/core'
 
-import { isReleaseVersionWorkspace }     from '../release-version-defer.command.js'
-import { parseDeferredReleaseDecisions } from '../release-version-defer.command.js'
-import { selectLocalCommitDiffParent }   from '../release-version-defer.command.js'
-import { toGitHubChange }                from '../release-version-defer.command.js'
+import { isReleaseVersionWorkspace }   from '../release-version-defer.command.js'
+import { selectLocalCommitDiffParent } from '../release-version-defer.command.js'
+import { toGitHubChange }              from '../release-version-defer.command.js'
 
 test('should include previous GitHub filenames for renamed files', () => {
   const change = toGitHubChange({
@@ -44,21 +43,6 @@ test('should fall back to the first parent when all merge parents are local', ()
     ),
     'feature-parent'
   )
-})
-
-test('should preserve declined deferred decisions', () => {
-  const decisions = parseDeferredReleaseDecisions(
-    [
-      'declined:',
-      '  - "@atls/code-runtime"',
-      'releases:',
-      '  "@atls/code-runtime": minor',
-      '  "@atls/code-test": patch',
-    ].join('\n')
-  )
-
-  assert.equal(decisions.get('@atls/code-runtime'), 'decline')
-  assert.equal(decisions.get('@atls/code-test'), 'patch')
 })
 
 test('should include private versioned workspaces in release version policy', () => {

--- a/yarn/plugin-release/sources/tests/release-version-policy.utils.test.ts
+++ b/yarn/plugin-release/sources/tests/release-version-policy.utils.test.ts
@@ -4,8 +4,6 @@ import type { ReleaseVersionWorkspace }             from '../release-version-pol
 import assert                                       from 'node:assert/strict'
 import { test }                                     from 'node:test'
 
-import { mergeReleaseVersionDeferredDecision }      from '../release-version-policy.utils.js'
-import { resolveReleaseVersionDeferredStrategy }    from '../release-version-policy.utils.js'
 import { resolveReleaseVersionStrategy }            from '../release-version-policy.utils.js'
 import { resolveReleaseVersionWorkspaceStrategies } from '../release-version-policy.utils.js'
 
@@ -107,29 +105,6 @@ test('should map release affecting conventional commits to patch strategy', () =
 
 test('should ignore non conventional commits', () => {
   assert.equal(resolveReleaseVersionStrategy('update runtime'), undefined)
-})
-
-test('should preserve higher existing deferred release strategy', () => {
-  assert.equal(resolveReleaseVersionDeferredStrategy('minor', 'patch'), 'minor')
-  assert.equal(resolveReleaseVersionDeferredStrategy('major', 'patch'), 'major')
-})
-
-test('should raise lower existing deferred release strategy', () => {
-  assert.equal(resolveReleaseVersionDeferredStrategy('patch', 'minor'), 'minor')
-  assert.equal(resolveReleaseVersionDeferredStrategy('minor', 'major'), 'major')
-})
-
-test('should preserve non-conventional existing deferred decisions', () => {
-  assert.equal(resolveReleaseVersionDeferredStrategy('2.0.0', 'patch'), '2.0.0')
-  assert.equal(resolveReleaseVersionDeferredStrategy('decline', 'minor'), 'decline')
-})
-
-test('should merge existing deferred release decisions without downgrade', () => {
-  assert.equal(mergeReleaseVersionDeferredDecision(undefined, 'patch'), 'patch')
-  assert.equal(mergeReleaseVersionDeferredDecision('minor', 'patch'), 'minor')
-  assert.equal(mergeReleaseVersionDeferredDecision('patch', 'major'), 'major')
-  assert.equal(mergeReleaseVersionDeferredDecision('2.0.0', 'minor'), '2.0.0')
-  assert.equal(mergeReleaseVersionDeferredDecision('minor', 'decline'), 'decline')
 })
 
 test('should resolve strategies per changed workspace', () => {

--- a/yarn/plugin-release/sources/tests/release-version-policy.utils.test.ts
+++ b/yarn/plugin-release/sources/tests/release-version-policy.utils.test.ts
@@ -4,6 +4,8 @@ import type { ReleaseVersionWorkspace }             from '../release-version-pol
 import assert                                       from 'node:assert/strict'
 import { test }                                     from 'node:test'
 
+import { mergeReleaseVersionDeferredDecision }      from '../release-version-policy.utils.js'
+import { resolveReleaseVersionDeferredStrategy }    from '../release-version-policy.utils.js'
 import { resolveReleaseVersionStrategy }            from '../release-version-policy.utils.js'
 import { resolveReleaseVersionWorkspaceStrategies } from '../release-version-policy.utils.js'
 
@@ -35,6 +37,19 @@ const workspaceOwners = [...workspaces, privateWorkspace, privateRuntimeWorkspac
 
 test('should map feature commits to minor strategy', () => {
   assert.equal(resolveReleaseVersionStrategy('feat(runtime): add loader'), 'minor')
+})
+
+test('should preserve explicit deferred decisions over computed strategies', () => {
+  assert.equal(resolveReleaseVersionDeferredStrategy('major', 'patch'), 'major')
+  assert.equal(resolveReleaseVersionDeferredStrategy('2.0.0', 'patch'), '2.0.0')
+  assert.equal(resolveReleaseVersionDeferredStrategy('decline', 'patch'), 'decline')
+})
+
+test('should merge deferred decisions by preserving explicit decisions and highest strategy', () => {
+  assert.equal(mergeReleaseVersionDeferredDecision('patch', 'minor'), 'minor')
+  assert.equal(mergeReleaseVersionDeferredDecision('major', 'patch'), 'major')
+  assert.equal(mergeReleaseVersionDeferredDecision('patch', '2.0.0'), '2.0.0')
+  assert.equal(mergeReleaseVersionDeferredDecision('decline', 'patch'), 'decline')
 })
 
 test('should map breaking commits to major strategy', () => {


### PR DESCRIPTION
## Task
- Part of atls/raijin#730
- Follow-up to atls/raijin#731

## How to Verify
### Before Fix
1. Context: release plan creation after deferred versions are already applied
Action: build the plan from changed-file strategies and current manifest versions
Expected result: the plan can bump already-applied versions again because deferred files are gone

2. Context: release plan creation when `.yarn/versions` has a deferred workspace outside the selected git range
Action: build the plan only from changed-file strategies
Expected result: the deferred-only workspace is omitted from the plan even though Yarn would apply it

3. Context: release plan creation with multiple deferred files for the same workspace
Action: aggregate deferred decisions with Raijin-owned parsing and merge rules
Expected result: the plan can keep stale or declined decisions that differ from Yarn `version apply --all`

### After Fix
1. Context: release plan creation between `yarn release version defer` and `yarn version apply --all`
Action: resolve target versions through Yarn `versionUtils.resolveVersionFiles(project)`
Expected result: the plan records Yarn-owned target versions, includes deferred-only workspaces, and fails early if a changed workspace has no deferred target

## Proofs
- `yarn test unit release-plan --test-reporter=tap`
- `yarn test unit release-version --test-reporter=tap`
- `yarn typecheck yarn/plugin-release/sources/release-plan-create.command.ts yarn/plugin-release/sources/release-plan.utils.ts yarn/plugin-release/sources/release-version-defer.command.ts yarn/plugin-release/sources/release-version-policy.utils.ts yarn/plugin-release/sources/tests/release-plan.utils.test.ts yarn/plugin-release/sources/tests/release-version-defer.command.test.ts yarn/plugin-release/sources/tests/release-version-policy.utils.test.ts`
- `yarn lint yarn/plugin-release/sources/release-plan-create.command.ts yarn/plugin-release/sources/release-plan.utils.ts yarn/plugin-release/sources/release-version-defer.command.ts yarn/plugin-release/sources/release-version-policy.utils.ts yarn/plugin-release/sources/tests/release-plan.utils.test.ts yarn/plugin-release/sources/tests/release-version-defer.command.test.ts yarn/plugin-release/sources/tests/release-version-policy.utils.test.ts`
- `yarn workspace @atls/yarn-plugin-release build`
- `yarn workspace @atls/yarn-cli build`
- `cmp -s yarn/cli/dist/yarn.mjs .yarn/releases/yarn.mjs`
- `yarn check`
- `yarn raijin:check`
- `git diff --check -- ':!yarn/cli/dist/yarn.mjs' ':!.yarn/releases/yarn.mjs'`
