### PR TITLE
fix(yarn-plugin-library): clean private package publish metadata

### DIFF
--- a/yarn/cli/package.json
+++ b/yarn/cli/package.json
@@ -84,19 +84,6 @@
     "semver": "7.6.3",
     "typanion": "3.14.0"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
-  },
   "@yarnpkg/builder": {
     "bundles": {
       "standard": [
@@ -148,6 +135,20 @@
         "@yarnpkg/plugin-pnpm",
         "@yarnpkg/plugin-stage"
       ]
+    }
+  },
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
     }
   }
 }

--- a/yarn/pack-utils/package.json
+++ b/yarn/pack-utils/package.json
@@ -24,17 +24,18 @@
     "@yarnpkg/plugin-patch": "4.0.3",
     "tar-stream": "3.1.7"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-changelog/package.json
+++ b/yarn/plugin-changelog/package.json
@@ -29,17 +29,18 @@
     "@yarnpkg/cli": "*",
     "@yarnpkg/core": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-check/package.json
+++ b/yarn/plugin-check/package.json
@@ -25,17 +25,18 @@
     "@yarnpkg/cli": "*",
     "@yarnpkg/core": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-checks/package.json
+++ b/yarn/plugin-checks/package.json
@@ -50,17 +50,18 @@
     "@yarnpkg/core": "*",
     "@yarnpkg/fslib": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-cli-publish/package.json
+++ b/yarn/plugin-cli-publish/package.json
@@ -29,17 +29,18 @@
     "@yarnpkg/core": "*",
     "@yarnpkg/fslib": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-commit/package.json
+++ b/yarn/plugin-commit/package.json
@@ -41,17 +41,18 @@
     "@yarnpkg/core": "*",
     "@yarnpkg/fslib": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-essentials/package.json
+++ b/yarn/plugin-essentials/package.json
@@ -32,17 +32,18 @@
     "@yarnpkg/core": "*",
     "@yarnpkg/plugin-git": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-export/package.json
+++ b/yarn/plugin-export/package.json
@@ -32,17 +32,18 @@
     "@yarnpkg/cli": "*",
     "@yarnpkg/core": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-files/package.json
+++ b/yarn/plugin-files/package.json
@@ -30,17 +30,18 @@
     "@yarnpkg/cli": "*",
     "@yarnpkg/core": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-format/package.json
+++ b/yarn/plugin-format/package.json
@@ -36,17 +36,18 @@
     "@yarnpkg/cli": "*",
     "@yarnpkg/core": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-image/package.json
+++ b/yarn/plugin-image/package.json
@@ -35,17 +35,18 @@
     "@yarnpkg/core": "*",
     "@yarnpkg/fslib": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-library/package.json
+++ b/yarn/plugin-library/package.json
@@ -40,9 +40,18 @@
     "@yarnpkg/cli": "*",
     "@yarnpkg/core": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "main": "dist/index.js",
-    "typings": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-library/sources/before-workspace-packing.hook.ts
+++ b/yarn/plugin-library/sources/before-workspace-packing.hook.ts
@@ -1,19 +1,46 @@
 import type { Workspace } from '@yarnpkg/core'
 
+interface PackManifest {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  exports?: Record<string, any>
+  main?: string
+  types?: string
+  typings?: string
+}
+
+interface RaijinManifest {
+  pack?: PackManifest
+}
+
 export interface RawManifest {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   exports?: Record<string, any>
+  main?: string
+  types?: string
+  typings?: string
 
-  publishConfig?: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    exports?: Record<string, any>
-  }
+  publishConfig?: PackManifest
+  raijin?: RaijinManifest
 }
 
-export const beforeWorkspacePacking = (_: Workspace, rawManifest: RawManifest): void => {
-  if (rawManifest.publishConfig) {
-    if (rawManifest.publishConfig.exports) {
-      rawManifest.exports = rawManifest.publishConfig.exports
-    }
+const applyPackManifest = (rawManifest: RawManifest, packManifest?: PackManifest): void => {
+  if (!packManifest) {
+    return
   }
+
+  if (packManifest.exports) rawManifest.exports = packManifest.exports
+  if (packManifest.main) rawManifest.main = packManifest.main
+  if (packManifest.types) rawManifest.types = packManifest.types
+  if (packManifest.typings) rawManifest.typings = packManifest.typings
+}
+
+export const beforeWorkspacePacking = (workspace: Workspace, rawManifest: RawManifest): void => {
+  const isPrivateWorkspace = workspace.manifest.private
+
+  applyPackManifest(
+    rawManifest,
+    isPrivateWorkspace ? rawManifest.raijin?.pack : rawManifest.publishConfig
+  )
+
+  delete rawManifest.raijin
 }

--- a/yarn/plugin-library/sources/tests/before-workspace-packing.hook.test.ts
+++ b/yarn/plugin-library/sources/tests/before-workspace-packing.hook.test.ts
@@ -1,0 +1,108 @@
+import type { Workspace }         from '@yarnpkg/core'
+
+import type { RawManifest }       from '../before-workspace-packing.hook.js'
+
+import assert                     from 'node:assert/strict'
+import { test }                   from 'node:test'
+
+import { beforeWorkspacePacking } from '../before-workspace-packing.hook.js'
+
+const createWorkspace = (isPrivate: boolean): Workspace =>
+  ({
+    manifest: {
+      private: isPrivate,
+    },
+  }) as Workspace
+
+test('should apply raijin pack metadata for private workspaces', () => {
+  const manifest: RawManifest = {
+    exports: {
+      '.': './sources/index.ts',
+    },
+    main: 'sources/index.ts',
+    raijin: {
+      pack: {
+        exports: {
+          '.': {
+            import: './dist/index.js',
+            types: './dist/index.d.ts',
+            default: './dist/index.js',
+          },
+        },
+        main: 'dist/index.js',
+        types: 'dist/index.d.ts',
+      },
+    },
+  }
+
+  beforeWorkspacePacking(createWorkspace(true), manifest)
+
+  assert.deepEqual(manifest, {
+    exports: {
+      '.': {
+        import: './dist/index.js',
+        types: './dist/index.d.ts',
+        default: './dist/index.js',
+      },
+    },
+    main: 'dist/index.js',
+    types: 'dist/index.d.ts',
+  })
+})
+
+test('should keep publishConfig metadata for public workspaces', () => {
+  const manifest: RawManifest = {
+    exports: {
+      '.': './sources/index.ts',
+    },
+    publishConfig: {
+      exports: {
+        '.': './dist/index.js',
+      },
+      main: 'dist/index.js',
+    },
+  }
+
+  beforeWorkspacePacking(createWorkspace(false), manifest)
+
+  assert.deepEqual(manifest, {
+    exports: {
+      '.': './dist/index.js',
+    },
+    main: 'dist/index.js',
+    publishConfig: {
+      exports: {
+        '.': './dist/index.js',
+      },
+      main: 'dist/index.js',
+    },
+  })
+})
+
+test('should ignore publishConfig metadata for private workspaces', () => {
+  const manifest: RawManifest = {
+    exports: {
+      '.': './sources/index.ts',
+    },
+    publishConfig: {
+      exports: {
+        '.': './dist/index.js',
+      },
+      main: 'dist/index.js',
+    },
+  }
+
+  beforeWorkspacePacking(createWorkspace(true), manifest)
+
+  assert.deepEqual(manifest, {
+    exports: {
+      '.': './sources/index.ts',
+    },
+    publishConfig: {
+      exports: {
+        '.': './dist/index.js',
+      },
+      main: 'dist/index.js',
+    },
+  })
+})

--- a/yarn/plugin-lint/package.json
+++ b/yarn/plugin-lint/package.json
@@ -39,17 +39,18 @@
     "@yarnpkg/cli": "*",
     "@yarnpkg/core": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-pnp-patch/package.json
+++ b/yarn/plugin-pnp-patch/package.json
@@ -35,17 +35,18 @@
     "rollup-plugin-esbuild": "6.1.1",
     "tslib": "2.7.0"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-release/package.json
+++ b/yarn/plugin-release/package.json
@@ -35,17 +35,18 @@
     "@yarnpkg/cli": "*",
     "@yarnpkg/core": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-renderer/package.json
+++ b/yarn/plugin-renderer/package.json
@@ -35,17 +35,18 @@
     "@yarnpkg/cli": "^4",
     "@yarnpkg/core": "^4"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-schematics/package.json
+++ b/yarn/plugin-schematics/package.json
@@ -43,9 +43,18 @@
     "ink": "*",
     "react": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "main": "dist/index.js",
-    "typings": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-service/package.json
+++ b/yarn/plugin-service/package.json
@@ -41,17 +41,18 @@
     "@yarnpkg/cli": "*",
     "@yarnpkg/core": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-test/package.json
+++ b/yarn/plugin-test/package.json
@@ -43,17 +43,18 @@
     "@yarnpkg/cli": "*",
     "@yarnpkg/core": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-tools/package.json
+++ b/yarn/plugin-tools/package.json
@@ -33,22 +33,23 @@
     "@yarnpkg/core": "4.7.0",
     "@yarnpkg/fslib": "3.1.5"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      "./current-yarn-executable": {
-        "import": "./dist/current-yarn-executable.js",
-        "types": "./dist/current-yarn-executable.d.ts",
-        "default": "./dist/current-yarn-executable.js"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        "./current-yarn-executable": {
+          "import": "./dist/current-yarn-executable.js",
+          "types": "./dist/current-yarn-executable.d.ts",
+          "default": "./dist/current-yarn-executable.js"
+        },
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
       },
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-typescript/package.json
+++ b/yarn/plugin-typescript/package.json
@@ -41,9 +41,18 @@
     "@yarnpkg/cli": "*",
     "@yarnpkg/core": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "main": "dist/index.js",
-    "typings": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-ui/package.json
+++ b/yarn/plugin-ui/package.json
@@ -39,17 +39,18 @@
     "@yarnpkg/cli": "*",
     "@yarnpkg/core": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }

--- a/yarn/plugin-workspaces/package.json
+++ b/yarn/plugin-workspaces/package.json
@@ -30,17 +30,18 @@
     "@yarnpkg/cli": "*",
     "@yarnpkg/core": "*"
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./package.json": "./package.json",
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    },
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+  "raijin": {
+    "pack": {
+      "exports": {
+        "./package.json": "./package.json",
+        ".": {
+          "import": "./dist/index.js",
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts"
+    }
   }
 }


### PR DESCRIPTION
## Task
- Close atls/raijin#707

## How to verify
### Before fix
1. Context: private Raijin Yarn workspaces used package manifests as both workspace runtime manifests and pack-time manifests.
Action: Inspect private `yarn/*/package.json` manifests or pack a private Yarn plugin.
Expected result: Before fix, private internal packages carried `publishConfig`, mixing registry publish metadata with pack metadata.

### After fix
1. Context: private Raijin Yarn workspace manifests.
Action: Inspect private `yarn/*/package.json` manifests.
Expected result: Private workspaces keep `private: true`, do not define `publishConfig`, and expose pack-only metadata through the internal `raijin.pack` contract consumed by `@atls/yarn-plugin-library`.

2. Context: packed private Yarn plugin manifests.
Action: Pack `@atls/yarn-plugin-checks` and `@atls/yarn-plugin-library`, then inspect `package/package.json` inside each archive.
Expected result: Packed manifests contain dist-oriented `main`, `types`, and `exports`, and contain neither `publishConfig` nor the internal `raijin` field.

## Proofs
- `yarn test unit before-workspace-packing --test-reporter=tap` passed.
- `yarn workspace @atls/yarn-plugin-checks pack --out /tmp/raijin-yarn-plugin-checks.tgz` proof passed: packed manifest has `main: dist/index.js`, `types: dist/index.d.ts`, `exports["."].import: ./dist/index.js`, no `publishConfig`, no `raijin`.
- `yarn workspace @atls/yarn-plugin-library pack --out /tmp/raijin-yarn-plugin-library.tgz` proof passed with the same packed manifest contract.
- `yarn workspace @atls/yarn-plugin-library build` passed.
- `yarn workspace @atls/yarn-cli build` passed.
- `cmp -s yarn/cli/dist/yarn.mjs .yarn/releases/yarn.mjs` passed.
- `git diff --check -- ':!yarn/cli/dist/yarn.mjs' ':!.yarn/releases/yarn.mjs'` passed.
- `yarn check` exited 0. Existing unrelated lint warning remains in `config/prettier/src/index.ts`.
- `yarn raijin:check` exited 0.
