### PR TITLE
fix(config-eslint): allow generated eslint config

### DIFF
--- a/code/code-lint/src/linter.test.ts
+++ b/code/code-lint/src/linter.test.ts
@@ -1,13 +1,15 @@
-import assert        from 'node:assert/strict'
-import { mkdtemp }   from 'node:fs/promises'
-import { writeFile } from 'node:fs/promises'
-import { tmpdir }    from 'node:os'
-import { join }      from 'node:path'
-import { test }      from 'node:test'
+import type { LintOptions } from './linter.js'
 
-import { Linter }    from './linter.js'
+import assert               from 'node:assert/strict'
+import { mkdtemp }          from 'node:fs/promises'
+import { writeFile }        from 'node:fs/promises'
+import { tmpdir }           from 'node:os'
+import { join }             from 'node:path'
+import { test }             from 'node:test'
 
-test('should lint generated eslint config outside tsconfig scope', async () => {
+import { Linter }           from './linter.js'
+
+const createProjectWithGeneratedEslintConfig = async (): Promise<string> => {
   const cwd = await mkdtemp(join(tmpdir(), 'raijin-lint-'))
 
   await writeFile(join(cwd, 'package.json'), '{"type":"module"}\n')
@@ -15,9 +17,27 @@ test('should lint generated eslint config outside tsconfig scope', async () => {
   await writeFile(join(cwd, 'project.types.d.ts'), 'export {}\n')
   await writeFile(join(cwd, '.eslintrc.js'), 'module.exports = {}\n')
 
+  return cwd
+}
+
+const lintGeneratedEslintConfig = async (options?: LintOptions): Promise<string> => {
+  const cwd = await createProjectWithGeneratedEslintConfig()
   const linter = await Linter.initialize(cwd, cwd)
-  const [result] = await linter.lint([join(cwd, '.eslintrc.js')], { cache: true })
-  const messages = result.messages.map((message) => message.message).join('\n')
+
+  const [result] = await linter.lint([join(cwd, '.eslintrc.js')], options)
+
+  return result.messages.map((message) => message.message).join('\n')
+}
+
+test('should lint generated eslint config outside tsconfig scope without cache', async () => {
+  const messages = await lintGeneratedEslintConfig()
+
+  assert.doesNotMatch(messages, /No matching configuration found/)
+  assert.doesNotMatch(messages, /was not found by the project service/)
+})
+
+test('should lint generated eslint config outside tsconfig scope with cache', async () => {
+  const messages = await lintGeneratedEslintConfig({ cache: true })
 
   assert.doesNotMatch(messages, /was not found by the project service/)
 })

--- a/code/code-lint/src/linter.test.ts
+++ b/code/code-lint/src/linter.test.ts
@@ -1,0 +1,23 @@
+import assert        from 'node:assert/strict'
+import { mkdtemp }   from 'node:fs/promises'
+import { writeFile } from 'node:fs/promises'
+import { tmpdir }    from 'node:os'
+import { join }      from 'node:path'
+import { test }      from 'node:test'
+
+import { Linter }    from './linter.js'
+
+test('should lint generated eslint config outside tsconfig scope', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'raijin-lint-'))
+
+  await writeFile(join(cwd, 'package.json'), '{"type":"module"}\n')
+  await writeFile(join(cwd, 'tsconfig.json'), '{"include":["project.types.d.ts"]}\n')
+  await writeFile(join(cwd, 'project.types.d.ts'), 'export {}\n')
+  await writeFile(join(cwd, '.eslintrc.js'), 'module.exports = {}\n')
+
+  const linter = await Linter.initialize(cwd, cwd)
+  const [result] = await linter.lint([join(cwd, '.eslintrc.js')], { cache: true })
+  const messages = result.messages.map((message) => message.message).join('\n')
+
+  assert.doesNotMatch(messages, /was not found by the project service/)
+})

--- a/code/code-lint/src/linter.ts
+++ b/code/code-lint/src/linter.ts
@@ -7,7 +7,9 @@ import EventEmitter            from 'node:events'
 import { readFileSync }        from 'node:fs'
 import { readFile }            from 'node:fs/promises'
 import { writeFile }           from 'node:fs/promises'
+import { isAbsolute }          from 'node:path'
 import { relative }            from 'node:path'
+import { resolve }             from 'node:path'
 import { join }                from 'node:path'
 
 import { globby }              from 'globby'
@@ -65,25 +67,27 @@ export class Linter extends EventEmitter {
   }
 
   async lintFile(filename: string, options?: LintOptions): Promise<LintResult> {
-    const source = await readFile(filename, 'utf8')
+    const filePath = this.resolveFilePath(filename)
+    const lintFilename = relative(this.cwd, filePath)
+    const source = await readFile(filePath, 'utf8')
 
     if (options?.fix) {
       const { messages, fixed, output } = this.linter.verifyAndFix(source, this.config, {
-        filename,
+        filename: lintFilename,
       })
 
       if (fixed) {
-        await writeFile(filename, output, 'utf8')
+        await writeFile(filePath, output, 'utf8')
       }
 
-      return createLintResult(filename, output, messages)
+      return createLintResult(filePath, output, messages)
     }
 
     return createLintResult(
-      filename,
+      filePath,
       source,
       this.linter.verify(source, this.config, {
-        filename,
+        filename: lintFilename,
       })
     )
   }
@@ -110,7 +114,9 @@ export class Linter extends EventEmitter {
 
   async lint(files?: Array<string>, options?: LintOptions): Promise<Array<LintResult>> {
     const filesForLint =
-      files && files.length > 0 ? files : await globby(createPatterns(this.cwd), { dot: true })
+      files && files.length > 0
+        ? files.map((file) => this.resolveFilePath(file))
+        : await globby(createPatterns(this.cwd), { dot: true })
 
     const finalFiles = filesForLint.filter(
       (file) => this.ignore.filter([relative(this.cwd, file)]).length !== 0
@@ -144,5 +150,9 @@ export class Linter extends EventEmitter {
     const { linterIgnorePatterns = [] } = JSON.parse(content)
 
     return linterIgnorePatterns as Array<string>
+  }
+
+  private resolveFilePath(file: string): string {
+    return isAbsolute(file) ? file : resolve(this.cwd, file)
   }
 }

--- a/config/eslint/src/index.test.ts
+++ b/config/eslint/src/index.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict'
+import test   from 'node:test'
+
+import config from './index.js'
+
+test('should allow generated project config files outside tsconfig scope', () => {
+  const [baseConfig] = config
+  const allowDefaultProject =
+    baseConfig.languageOptions?.parserOptions?.projectService?.allowDefaultProject
+
+  assert.deepEqual(allowDefaultProject, ['scripts/raijin/*.mjs', '.eslintrc.js', '.prettierrc.mjs'])
+})

--- a/config/eslint/src/index.ts
+++ b/config/eslint/src/index.ts
@@ -61,7 +61,7 @@ const config: Array<Linter.Config> = [
       parser,
       parserOptions: {
         projectService: {
-          allowDefaultProject: ['scripts/raijin/*.mjs', '.prettierrc.mjs'],
+          allowDefaultProject: ['scripts/raijin/*.mjs', '.eslintrc.js', '.prettierrc.mjs'],
         },
         ecmaFeatures: {
           jsx: true,

--- a/runtime/code-runtime/unit/eslint-config.test.ts
+++ b/runtime/code-runtime/unit/eslint-config.test.ts
@@ -1,0 +1,12 @@
+import assert           from 'node:assert/strict'
+import { test }         from 'node:test'
+
+import { eslintconfig } from '../src/eslint.js'
+
+test('should allow generated project config files outside tsconfig scope', () => {
+  const [baseConfig] = eslintconfig
+  const allowDefaultProject =
+    baseConfig.languageOptions?.parserOptions?.projectService?.allowDefaultProject
+
+  assert.deepEqual(allowDefaultProject, ['scripts/raijin/*.mjs', '.eslintrc.js', '.prettierrc.mjs'])
+})


### PR DESCRIPTION
## Task

- Close atls/raijin#761

## How to verify

### Before the fix

1. Context: a freshly initialized Raijin project generated by `yarn init @atls/raijin`
   Action: run `yarn check`
   Expected result: lint emits a TypeScript project-service warning for `.eslintrc.js` because the shared ESLint `allowDefaultProject` list only includes `scripts/raijin/*.mjs` and `.prettierrc.mjs`.

### After the fix

1. Context: shared ESLint configuration
   Action: inspect `projectService.allowDefaultProject`
   Expected result: `.eslintrc.js` is allowed together with the existing generated project config files.
2. Context: `@atls/code-runtime/eslint`, which generated projects consume through `code-lint`
   Action: inspect the exported ESLint config
   Expected result: the same allow list includes `.eslintrc.js`.
3. Context: `code-lint` running against a generated `.eslintrc.js` outside the local `tsconfig.json` include scope
   Action: lint that file in a temporary project
   Expected result: the TypeScript project-service warning is absent.

## Proofs

- Targeted formatting

```bash
yarn format config/eslint/src/index.ts config/eslint/src/index.test.ts runtime/code-runtime/unit/eslint-config.test.ts code/code-lint/src/linter.test.ts
```

- Targeted lint and typecheck

```bash
yarn lint config/eslint/src/index.ts config/eslint/src/index.test.ts runtime/code-runtime/unit/eslint-config.test.ts code/code-lint/src/linter.test.ts
yarn typecheck config/eslint/src/index.ts config/eslint/src/index.test.ts runtime/code-runtime/unit/eslint-config.test.ts code/code-lint/src/linter.test.ts
```

- Unit tests

```bash
yarn test unit config/eslint/src/index.test.ts --test-reporter=tap
yarn test unit runtime/code-runtime/unit/eslint-config.test.ts --test-reporter=tap
yarn test unit code/code-lint/src/linter.test.ts --test-reporter=tap
```

- Package builds

```bash
yarn workspace @atls/config-eslint build
yarn workspace @atls/code-runtime build
yarn workspace @atls/code-lint build
```

- Repository checks

```bash
git diff --check
yarn check
yarn raijin:check
git verify-commit HEAD
```
