### PR TITLE
test(raijin): guard stock PnP init templates

### DIFF
--- a/code/code-schematics/src/scripts/schematic-smoke.ts
+++ b/code/code-schematics/src/scripts/schematic-smoke.ts
@@ -35,6 +35,14 @@ const requiredGeneratedFiles = [
   'tsconfig.json',
 ]
 
+const forbiddenGeneratedPaths = ['.yarn/bin/yarn', '.yarn/plugins/@atls/yarn-plugin-pnp-patch.cjs']
+
+const forbiddenGeneratedContent = [
+  '@atls/yarn-plugin-pnp-patch',
+  'yarn-plugin-pnp-patch',
+  '.yarn/bin/yarn',
+]
+
 const readJson = async <T>(filePath: string): Promise<T> =>
   JSON.parse(await fs.readFile(filePath, 'utf8')) as T
 
@@ -201,6 +209,38 @@ const assertGeneratedFixture = async (fixtureDir: string): Promise<void> => {
 
   if (!tsconfig.compilerOptions || typeof tsconfig.compilerOptions !== 'object') {
     throw new Error('Generated tsconfig.json does not contain compilerOptions')
+  }
+
+  const forbiddenPaths = []
+
+  for (const relativePath of forbiddenGeneratedPaths) {
+    if (await pathExists(path.join(fixtureDir, relativePath))) {
+      forbiddenPaths.push(relativePath)
+    }
+  }
+
+  if (forbiddenPaths.length > 0) {
+    throw new Error(`Schematic smoke generated legacy runtime paths:\n${forbiddenPaths.join('\n')}`)
+  }
+
+  const generatedFiles = await walkFiles(fixtureDir)
+  const forbiddenContent = []
+
+  for (const filePath of generatedFiles) {
+    const content = await fs.readFile(filePath, 'utf8')
+    const relativePath = path.relative(fixtureDir, filePath)
+
+    for (const legacyRuntimeToken of forbiddenGeneratedContent) {
+      if (content.includes(legacyRuntimeToken)) {
+        forbiddenContent.push(`${relativePath}: contains ${legacyRuntimeToken}`)
+      }
+    }
+  }
+
+  if (forbiddenContent.length > 0) {
+    throw new Error(
+      `Schematic smoke generated legacy runtime references:\n${forbiddenContent.join('\n')}`
+    )
   }
 }
 

--- a/yarn/raijin/src/initializer/index.test.ts
+++ b/yarn/raijin/src/initializer/index.test.ts
@@ -1,6 +1,8 @@
 import assert                                                 from 'node:assert/strict'
+import { access }                                             from 'node:fs/promises'
 import { mkdtemp }                                            from 'node:fs/promises'
 import { readFile }                                           from 'node:fs/promises'
+import { readdir }                                            from 'node:fs/promises'
 import { writeFile }                                          from 'node:fs/promises'
 import { tmpdir }                                             from 'node:os'
 import { join }                                               from 'node:path'
@@ -79,6 +81,20 @@ const collectInitializerCommands = async (
 }
 
 const noopYarnCommand = async (): Promise<void> => undefined
+
+const pathExists = async (path: string): Promise<boolean> => {
+  try {
+    await access(path)
+
+    return true
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return false
+    }
+
+    throw error
+  }
+}
 
 test('should run initializer command sequence', async () => {
   assert.deepEqual(
@@ -203,6 +219,25 @@ test('should create project lockfile boundary before yarn commands', async () =>
   })
 
   assert.equal(await readFile(join(cwd, 'yarn.lock'), 'utf-8'), '')
+})
+
+test('should initialize stock pnp runtime layout', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'raijin-initializer-'))
+
+  await runRaijinInitializer({
+    argv: ['init'],
+    cwd,
+    fetchImpl: createFetch(Buffer.from('runtime')),
+    runYarnCommand: noopYarnCommand,
+  })
+
+  assert.equal(
+    await readFile(join(cwd, '.yarnrc.yml'), 'utf-8'),
+    'nodeLinker: pnp\nyarnPath: .yarn/releases/yarn.mjs\n'
+  )
+  assert.deepEqual(await readdir(join(cwd, '.yarn/releases')), ['yarn.mjs'])
+  assert.equal(await pathExists(join(cwd, '.yarn/bin/yarn')), false)
+  assert.equal(await pathExists(join(cwd, '.yarn/releases/yarn-remote.mjs')), false)
 })
 
 test('should preserve existing project lockfile boundary', async () => {


### PR DESCRIPTION
## Task

- Close atls/raijin#681

## How to verify

### Before the fix

1. Context: Raijin package initialization smoke.
   Action: Generate the package initialization fixture without stock runtime guardrails.
   Expected result: Old runtime wrapper paths or patched PnP references could return to generated output without failing the smoke.

### After the fix

1. Context: Raijin package initialization smoke and initializer unit coverage.
   Action: Run the schematic smoke and initializer tests.
   Expected result: Generated output fails if it contains `@atls/yarn-plugin-pnp-patch`, `.yarn/bin/yarn`, or old runtime wrapper references, and initializer output keeps `nodeLinker: pnp` with `.yarn/releases/yarn.mjs` only.

## Proofs

- `yarn format code/code-schematics/src/scripts/schematic-smoke.ts yarn/raijin/src/initializer/index.test.ts`
- `yarn lint code/code-schematics/src/scripts/schematic-smoke.ts yarn/raijin/src/initializer/index.test.ts`
- `yarn typecheck code/code-schematics/src/scripts/schematic-smoke.ts yarn/raijin/src/initializer/index.test.ts`
- `yarn test unit yarn/raijin/src/initializer/index.test.ts --test-reporter=tap`
- `yarn workspace @atls/code-schematics run smoke:schematic`
- `yarn workspace @atls/code-schematics build`
- `yarn workspace @atls/raijin build`
- `git diff --check`
- `yarn raijin:check`
- `yarn check`
- `git verify-commit HEAD`
