### PR TITLE
fix(code): normalize explicit directory targets

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2060,7 +2060,8 @@ const RAW_RUNTIME_STATE =
           ["@types/yarnpkg__core", null],\
           ["@yarnpkg/builder", "https://github.com/TorinAsakura/yarnpkg-builder.git#commit=05a30e58225e52c7fa61664aa939f1fd7fedb7b6"],\
           ["@yarnpkg/cli", "virtual:8e172b7de094f5df1f73b42159c07665b055baad33e200e181c35f4b480aea8d16ffc372d00e648328df631585117e06bc25130971454d9a1b4c4c91cb25ff1f#npm:4.14.1"],\
-          ["@yarnpkg/core", "npm:4.7.0"]\
+          ["@yarnpkg/core", "npm:4.7.0"],\
+          ["clipanion", "virtual:b80567f1f726ad28b5f69c2f4d583115762754ed5e643c8ffc700d555267034c078163b8acf27ac9e54b95573c3afeb591dde0dc0755beb1e2c159d60551a612#npm:4.0.0-rc.2"]\
         ],\
         "packagePeers": [\
           "@types/yarnpkg__cli",\
@@ -2076,7 +2077,8 @@ const RAW_RUNTIME_STATE =
           ["@atls/yarn-plugin-check", "workspace:yarn/plugin-check"],\
           ["@yarnpkg/builder", "https://github.com/TorinAsakura/yarnpkg-builder.git#commit=05a30e58225e52c7fa61664aa939f1fd7fedb7b6"],\
           ["@yarnpkg/cli", "virtual:8e172b7de094f5df1f73b42159c07665b055baad33e200e181c35f4b480aea8d16ffc372d00e648328df631585117e06bc25130971454d9a1b4c4c91cb25ff1f#npm:4.14.1"],\
-          ["@yarnpkg/core", "npm:4.7.0"]\
+          ["@yarnpkg/core", "npm:4.7.0"],\
+          ["clipanion", "virtual:b80567f1f726ad28b5f69c2f4d583115762754ed5e643c8ffc700d555267034c078163b8acf27ac9e54b95573c3afeb591dde0dc0755beb1e2c159d60551a612#npm:4.0.0-rc.2"]\
         ],\
         "linkType": "SOFT"\
       }]\

--- a/code/code-format/src/formatter.test.ts
+++ b/code/code-format/src/formatter.test.ts
@@ -31,6 +31,20 @@ test('should expand explicit directory targets before formatting files', async (
   assert.equal(await readFile(join(src, 'index.ts'), 'utf8'), 'const value = { foo: 1 }\n')
 })
 
+test('should expand explicit directory targets with glob metacharacters as literal paths', async () => {
+  const cwd = await createProject()
+  const src = join(cwd, 'src/[id]')
+
+  await mkdir(src, { recursive: true })
+  await writeFile(join(src, 'index.ts'), 'const value={foo:1}\n')
+
+  const formatter = await Formatter.initialize(cwd)
+
+  await formatter.format(['src/[id]'])
+
+  assert.equal(await readFile(join(src, 'index.ts'), 'utf8'), 'const value = { foo: 1 }\n')
+})
+
 test('should fail clearly when explicit formatter target does not exist', async () => {
   const cwd = await createProject()
   const formatter = await Formatter.initialize(cwd)

--- a/code/code-format/src/formatter.test.ts
+++ b/code/code-format/src/formatter.test.ts
@@ -1,0 +1,42 @@
+import assert        from 'node:assert/strict'
+import { mkdtemp }   from 'node:fs/promises'
+import { mkdir }     from 'node:fs/promises'
+import { readFile }  from 'node:fs/promises'
+import { writeFile } from 'node:fs/promises'
+import { tmpdir }    from 'node:os'
+import { join }      from 'node:path'
+import { test }      from 'node:test'
+
+import { Formatter } from './formatter.js'
+
+const createProject = async (): Promise<string> => {
+  const cwd = await mkdtemp(join(tmpdir(), 'raijin-format-'))
+
+  await writeFile(join(cwd, 'package.json'), `${JSON.stringify({ private: true })}\n`)
+
+  return cwd
+}
+
+test('should expand explicit directory targets before formatting files', async () => {
+  const cwd = await createProject()
+  const src = join(cwd, 'src')
+
+  await mkdir(src)
+  await writeFile(join(src, 'index.ts'), 'const value={foo:1}\n')
+
+  const formatter = await Formatter.initialize(cwd)
+
+  await formatter.format(['src'])
+
+  assert.equal(await readFile(join(src, 'index.ts'), 'utf8'), 'const value = { foo: 1 }\n')
+})
+
+test('should fail clearly when explicit formatter target does not exist', async () => {
+  const cwd = await createProject()
+  const formatter = await Formatter.initialize(cwd)
+
+  await assert.rejects(
+    async () => formatter.format(['missing']),
+    new Error('Formatter target does not exist: missing')
+  )
+})

--- a/code/code-format/src/formatter.ts
+++ b/code/code-format/src/formatter.ts
@@ -1,7 +1,9 @@
 import EventEmitter          from 'node:events'
+import { stat }              from 'node:fs/promises'
 import { writeFile }         from 'node:fs/promises'
 import { readFile }          from 'node:fs/promises'
 import { relative }          from 'node:path'
+import { resolve }           from 'node:path'
 import { join }              from 'node:path'
 
 import * as babel            from 'prettier/plugins/babel'
@@ -39,19 +41,21 @@ export class Formatter extends EventEmitter {
 
   protected async formatFiles(files: Array<string> = []): Promise<void> {
     const prettierPlugin = await getPrettierPlugin()
+    const targetFiles = await this.resolveFormatFiles(files)
 
     const formatFiles = ignorer
       .default()
       .add(ignore)
       .add(await this.getProjectIgnorePatterns())
-      .filter(files.map((filepath) => relative(this.cwd, filepath)))
+      .filter(targetFiles.map((filepath) => relative(this.cwd, filepath)))
 
     this.emit('start', { files: formatFiles })
 
     for await (const filename of formatFiles) {
       this.emit('format:start', { file: filename })
 
-      const input = await readFile(filename, 'utf8')
+      const targetFile = resolve(this.cwd, filename)
+      const input = await readFile(targetFile, 'utf8')
 
       const output = await format(input, {
         ...config,
@@ -61,7 +65,7 @@ export class Formatter extends EventEmitter {
       })
 
       if (output !== input && output) {
-        await writeFile(filename, output, 'utf8')
+        await writeFile(targetFile, output, 'utf8')
 
         this.emit('format:end', { file: filename, changed: true })
       } else {
@@ -78,6 +82,37 @@ export class Formatter extends EventEmitter {
     })
 
     await this.formatFiles(files)
+  }
+
+  protected async resolveFormatFiles(files: Array<string>): Promise<Array<string>> {
+    const resolvedFiles: Array<string> = []
+
+    for await (const filepath of files) {
+      const targetPath = resolve(this.cwd, filepath)
+      let targetStat
+
+      try {
+        targetStat = await stat(targetPath)
+      } catch (error) {
+        if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+          throw new Error(`Formatter target does not exist: ${filepath}`)
+        }
+
+        throw error
+      }
+
+      if (targetStat.isDirectory()) {
+        resolvedFiles.push(
+          ...(await globby(createPatterns(targetPath), {
+            dot: true,
+          }))
+        )
+      } else {
+        resolvedFiles.push(targetPath)
+      }
+    }
+
+    return Array.from(new Set(resolvedFiles))
   }
 
   protected async getProjectIgnorePatterns(): Promise<Array<string>> {

--- a/code/code-format/src/formatter.ts
+++ b/code/code-format/src/formatter.ts
@@ -103,8 +103,10 @@ export class Formatter extends EventEmitter {
 
       if (targetStat.isDirectory()) {
         resolvedFiles.push(
-          ...(await globby(createPatterns(targetPath), {
+          ...(await globby(createPatterns('.'), {
+            cwd: targetPath,
             dot: true,
+            absolute: true,
           }))
         )
       } else {

--- a/code/code-lint/src/linter.test.ts
+++ b/code/code-lint/src/linter.test.ts
@@ -59,6 +59,22 @@ test('should expand explicit directory targets before linting files', async () =
   )
 })
 
+test('should expand explicit directory targets with glob metacharacters as literal paths', async () => {
+  const cwd = await createProjectWithGeneratedEslintConfig()
+  const src = join(cwd, 'src/[id]')
+  const linter = await Linter.initialize(cwd, cwd)
+
+  await mkdir(src, { recursive: true })
+  await writeFile(join(src, 'index.ts'), 'export const value = 1\n')
+
+  const results = await linter.lint(['src/[id]'])
+
+  assert.deepEqual(
+    results.map((result) => result.filePath),
+    [join(src, 'index.ts')]
+  )
+})
+
 test('should fail clearly when explicit linter target does not exist', async () => {
   const cwd = await createProjectWithGeneratedEslintConfig()
   const linter = await Linter.initialize(cwd, cwd)

--- a/code/code-lint/src/linter.test.ts
+++ b/code/code-lint/src/linter.test.ts
@@ -1,6 +1,7 @@
 import type { LintOptions } from './linter.js'
 
 import assert               from 'node:assert/strict'
+import { mkdir }            from 'node:fs/promises'
 import { mkdtemp }          from 'node:fs/promises'
 import { writeFile }        from 'node:fs/promises'
 import { tmpdir }           from 'node:os'
@@ -13,7 +14,7 @@ const createProjectWithGeneratedEslintConfig = async (): Promise<string> => {
   const cwd = await mkdtemp(join(tmpdir(), 'raijin-lint-'))
 
   await writeFile(join(cwd, 'package.json'), '{"type":"module"}\n')
-  await writeFile(join(cwd, 'tsconfig.json'), '{"include":["project.types.d.ts"]}\n')
+  await writeFile(join(cwd, 'tsconfig.json'), '{"include":["project.types.d.ts","src/**/*.ts"]}\n')
   await writeFile(join(cwd, 'project.types.d.ts'), 'export {}\n')
   await writeFile(join(cwd, '.eslintrc.js'), 'module.exports = {}\n')
 
@@ -40,4 +41,30 @@ test('should lint generated eslint config outside tsconfig scope with cache', as
   const messages = await lintGeneratedEslintConfig({ cache: true })
 
   assert.doesNotMatch(messages, /was not found by the project service/)
+})
+
+test('should expand explicit directory targets before linting files', async () => {
+  const cwd = await createProjectWithGeneratedEslintConfig()
+  const src = join(cwd, 'src')
+  const linter = await Linter.initialize(cwd, cwd)
+
+  await mkdir(src)
+  await writeFile(join(src, 'index.ts'), 'export const value = 1\n')
+
+  const results = await linter.lint(['src'])
+
+  assert.deepEqual(
+    results.map((result) => result.filePath),
+    [join(src, 'index.ts')]
+  )
+})
+
+test('should fail clearly when explicit linter target does not exist', async () => {
+  const cwd = await createProjectWithGeneratedEslintConfig()
+  const linter = await Linter.initialize(cwd, cwd)
+
+  await assert.rejects(
+    async () => linter.lint(['missing']),
+    new Error('Linter target does not exist: missing')
+  )
 })

--- a/code/code-lint/src/linter.ts
+++ b/code/code-lint/src/linter.ts
@@ -183,8 +183,10 @@ export class Linter extends EventEmitter {
 
       if (targetStat.isDirectory()) {
         resolvedFiles.push(
-          ...(await globby(createPatterns(targetPath), {
+          ...(await globby(createPatterns('.'), {
+            cwd: targetPath,
             dot: true,
+            absolute: true,
           }))
         )
       } else {

--- a/code/code-lint/src/linter.ts
+++ b/code/code-lint/src/linter.ts
@@ -8,6 +8,7 @@ import type { LintResult }              from '@atls/raijin/eslint'
 import EventEmitter                     from 'node:events'
 import { readFileSync }                 from 'node:fs'
 import { readFile }                     from 'node:fs/promises'
+import { stat }                         from 'node:fs/promises'
 import { writeFile }                    from 'node:fs/promises'
 import { isAbsolute }                   from 'node:path'
 import { relative }                     from 'node:path'
@@ -126,7 +127,7 @@ export class Linter extends EventEmitter {
   async lint(files?: Array<string>, options?: LintOptions): Promise<Array<LintResult>> {
     const filesForLint =
       files && files.length > 0
-        ? files.map((file) => this.resolveFilePath(file))
+        ? await this.resolveLintFiles(files)
         : await globby(createPatterns(this.cwd), { dot: true })
 
     const finalFiles = filesForLint.filter(
@@ -161,6 +162,37 @@ export class Linter extends EventEmitter {
     const { linterIgnorePatterns = [] } = JSON.parse(content)
 
     return linterIgnorePatterns as Array<string>
+  }
+
+  private async resolveLintFiles(files: Array<string>): Promise<Array<string>> {
+    const resolvedFiles: Array<string> = []
+
+    for await (const file of files) {
+      const targetPath = this.resolveFilePath(file)
+      let targetStat
+
+      try {
+        targetStat = await stat(targetPath)
+      } catch (error) {
+        if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+          throw new Error(`Linter target does not exist: ${file}`)
+        }
+
+        throw error
+      }
+
+      if (targetStat.isDirectory()) {
+        resolvedFiles.push(
+          ...(await globby(createPatterns(targetPath), {
+            dot: true,
+          }))
+        )
+      } else {
+        resolvedFiles.push(targetPath)
+      }
+    }
+
+    return Array.from(new Set(resolvedFiles))
   }
 
   private resolveFilePath(file: string): string {

--- a/code/code-test/src/tester.test.ts
+++ b/code/code-test/src/tester.test.ts
@@ -50,6 +50,60 @@ test('should expand explicit directory targets before collecting unit tests', as
   assert.deepEqual(files, [join(unit, 'sample.test.js')])
 })
 
+test('should collect unit tests directly under explicit directory targets', async () => {
+  const cwd = await createProject()
+  const src = join(cwd, 'src')
+  const tester = await Tester.initialize(cwd)
+
+  await mkdir(src, { recursive: true })
+  await writeFile(
+    join(src, 'formatter.test.js'),
+    [
+      "import assert from 'node:assert/strict'",
+      "import { test } from 'node:test'",
+      '',
+      "test('sample', () => {",
+      '  assert.equal(1, 1)',
+      '})',
+      '',
+    ].join('\n')
+  )
+
+  const files = await (tester as unknown as TestFileCollector).collectTestFiles(cwd, 'unit', [
+    'src',
+  ])
+
+  assert.deepEqual(files, [join(src, 'formatter.test.js')])
+})
+
+test('should collect tests directly under explicit integration directory targets', async () => {
+  const cwd = await createProject()
+  const integration = join(cwd, 'integration')
+  const tester = await Tester.initialize(cwd)
+
+  await mkdir(integration, { recursive: true })
+  await writeFile(
+    join(integration, 'sample.test.js'),
+    [
+      "import assert from 'node:assert/strict'",
+      "import { test } from 'node:test'",
+      '',
+      "test('sample', () => {",
+      '  assert.equal(1, 1)',
+      '})',
+      '',
+    ].join('\n')
+  )
+
+  const files = await (tester as unknown as TestFileCollector).collectTestFiles(
+    cwd,
+    'integration',
+    ['integration']
+  )
+
+  assert.deepEqual(files, [join(integration, 'sample.test.js')])
+})
+
 test('should expand explicit directory targets with glob metacharacters as literal paths', async () => {
   const cwd = await createProject()
   const unit = join(cwd, 'src/[id]/unit')

--- a/code/code-test/src/tester.test.ts
+++ b/code/code-test/src/tester.test.ts
@@ -50,6 +50,32 @@ test('should expand explicit directory targets before collecting unit tests', as
   assert.deepEqual(files, [join(unit, 'sample.test.js')])
 })
 
+test('should expand explicit directory targets with glob metacharacters as literal paths', async () => {
+  const cwd = await createProject()
+  const unit = join(cwd, 'src/[id]/unit')
+  const tester = await Tester.initialize(cwd)
+
+  await mkdir(unit, { recursive: true })
+  await writeFile(
+    join(unit, 'sample.test.js'),
+    [
+      "import assert from 'node:assert/strict'",
+      "import { test } from 'node:test'",
+      '',
+      "test('sample', () => {",
+      '  assert.equal(1, 1)',
+      '})',
+      '',
+    ].join('\n')
+  )
+
+  const files = await (tester as unknown as TestFileCollector).collectTestFiles(cwd, 'unit', [
+    'src/[id]',
+  ])
+
+  assert.deepEqual(files, [join(unit, 'sample.test.js')])
+})
+
 test('should fail clearly when explicit test target does not exist', async () => {
   const cwd = await createProject()
   const tester = await Tester.initialize(cwd)

--- a/code/code-test/src/tester.test.ts
+++ b/code/code-test/src/tester.test.ts
@@ -1,0 +1,65 @@
+import assert        from 'node:assert/strict'
+import { mkdir }     from 'node:fs/promises'
+import { mkdtemp }   from 'node:fs/promises'
+import { writeFile } from 'node:fs/promises'
+import { tmpdir }    from 'node:os'
+import { join }      from 'node:path'
+import { test }      from 'node:test'
+
+import { Tester }    from './tester.js'
+
+type TestFileCollector = {
+  collectTestFiles: (
+    cwd: string,
+    type: 'integration' | 'unit' | undefined,
+    patterns: Array<string> | undefined
+  ) => Promise<Array<string>>
+}
+
+const createProject = async (): Promise<string> => {
+  const cwd = await mkdtemp(join(tmpdir(), 'raijin-test-'))
+
+  await writeFile(join(cwd, 'package.json'), `${JSON.stringify({ type: 'module' })}\n`)
+
+  return cwd
+}
+
+test('should expand explicit directory targets before collecting unit tests', async () => {
+  const cwd = await createProject()
+  const unit = join(cwd, 'src/unit')
+  const tester = await Tester.initialize(cwd)
+
+  await mkdir(unit, { recursive: true })
+  await writeFile(
+    join(unit, 'sample.test.js'),
+    [
+      "import assert from 'node:assert/strict'",
+      "import { test } from 'node:test'",
+      '',
+      "test('sample', () => {",
+      '  assert.equal(1, 1)',
+      '})',
+      '',
+    ].join('\n')
+  )
+
+  const files = await (tester as unknown as TestFileCollector).collectTestFiles(cwd, 'unit', [
+    'src',
+  ])
+
+  assert.deepEqual(files, [join(unit, 'sample.test.js')])
+})
+
+test('should fail clearly when explicit test target does not exist', async () => {
+  const cwd = await createProject()
+  const tester = await Tester.initialize(cwd)
+
+  await assert.rejects(
+    async () =>
+      tester.unit(cwd, {
+        files: ['src/missing'],
+        testReporter: 'tap',
+      }),
+    new Error('Test target does not exist: src/missing')
+  )
+})

--- a/code/code-test/src/tester.ts
+++ b/code/code-test/src/tester.ts
@@ -3,8 +3,10 @@ import type { TestEvent }            from 'node:test/reporters'
 
 import EventEmitter                  from 'node:events'
 import { readFileSync }              from 'node:fs'
+import { stat }                      from 'node:fs/promises'
 /* eslint-disable @typescript-eslint/member-ordering */
 import { relative }                  from 'node:path'
+import { resolve as resolvePath }    from 'node:path'
 import { join }                      from 'node:path'
 import { run }                       from 'node:test'
 import { tap }                       from 'node:test/reporters'
@@ -262,25 +264,53 @@ export class Tester extends EventEmitter {
       })
     }
 
-    return globby(
-      patterns.map((pattern) => {
-        if (this.isFilename(pattern)) {
-          return `**/${folderPattern}/*${pattern}*.test.{ts,tsx,js,jsx}`
-        }
-
-        if (this.isRootPath(pattern)) {
-          return pattern
-        }
-
-        return `**/${pattern}`
-      }),
-      {
-        cwd,
-        dot: true,
-        absolute: true,
-        ignore: ['**/node_modules/**', '**/dist/**', '**/.yarn/**'],
-      }
+    const testFiles = await Promise.all(
+      patterns.map(async (pattern) => this.collectPatternTestFiles(cwd, folderPattern, pattern))
     )
+
+    return Array.from(new Set(testFiles.flat()))
+  }
+
+  private async collectPatternTestFiles(
+    cwd: string,
+    folderPattern: string,
+    pattern: string
+  ): Promise<Array<string>> {
+    const globbyOptions = {
+      cwd,
+      dot: true,
+      absolute: true,
+      ignore: ['**/node_modules/**', '**/dist/**', '**/.yarn/**'],
+    }
+
+    if (this.isGlobPattern(pattern)) {
+      return globby([pattern], globbyOptions)
+    }
+
+    const targetPath = resolvePath(cwd, pattern)
+    let targetStat
+
+    try {
+      targetStat = await stat(targetPath)
+    } catch (error) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        if (this.isFilename(pattern)) {
+          return globby([`**/${folderPattern}/*${pattern}*.test.{ts,tsx,js,jsx}`], globbyOptions)
+        }
+
+        throw new Error(`Test target does not exist: ${pattern}`)
+      }
+
+      throw error
+    }
+
+    if (targetStat.isDirectory()) {
+      const targetPattern = relative(cwd, targetPath) || '.'
+
+      return globby([`${targetPattern}/**/${folderPattern}/*.test.{ts,tsx,js,jsx}`], globbyOptions)
+    }
+
+    return [targetPath]
   }
 
   private isFilename(pattern: string): boolean {
@@ -291,8 +321,8 @@ export class Tester extends EventEmitter {
     return !hasPathSeparator && !hasValidExtension
   }
 
-  private isRootPath(pattern: string): boolean {
-    return pattern.startsWith('/') || pattern.startsWith('\\')
+  private isGlobPattern(pattern: string): boolean {
+    return /[*?[\]{}]/.test(pattern)
   }
 
   private getProjectIgnorePatterns(): Array<string> {

--- a/code/code-test/src/tester.ts
+++ b/code/code-test/src/tester.ts
@@ -283,10 +283,6 @@ export class Tester extends EventEmitter {
       ignore: ['**/node_modules/**', '**/dist/**', '**/.yarn/**'],
     }
 
-    if (this.isGlobPattern(pattern)) {
-      return globby([pattern], globbyOptions)
-    }
-
     const targetPath = resolvePath(cwd, pattern)
     let targetStat
 
@@ -294,6 +290,10 @@ export class Tester extends EventEmitter {
       targetStat = await stat(targetPath)
     } catch (error) {
       if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        if (this.isGlobPattern(pattern)) {
+          return globby([pattern], globbyOptions)
+        }
+
         if (this.isFilename(pattern)) {
           return globby([`**/${folderPattern}/*${pattern}*.test.{ts,tsx,js,jsx}`], globbyOptions)
         }
@@ -305,9 +305,10 @@ export class Tester extends EventEmitter {
     }
 
     if (targetStat.isDirectory()) {
-      const targetPattern = relative(cwd, targetPath) || '.'
-
-      return globby([`${targetPattern}/**/${folderPattern}/*.test.{ts,tsx,js,jsx}`], globbyOptions)
+      return globby([`**/${folderPattern}/*.test.{ts,tsx,js,jsx}`], {
+        ...globbyOptions,
+        cwd: targetPath,
+      })
     }
 
     return [targetPath]

--- a/code/code-test/src/tester.ts
+++ b/code/code-test/src/tester.ts
@@ -8,6 +8,7 @@ import { stat }                      from 'node:fs/promises'
 import { relative }                  from 'node:path'
 import { resolve as resolvePath }    from 'node:path'
 import { join }                      from 'node:path'
+import { basename }                  from 'node:path'
 import { run }                       from 'node:test'
 import { tap }                       from 'node:test/reporters'
 
@@ -31,6 +32,8 @@ type TestOptions = {
   watch?: boolean
   testReporter?: string
 }
+
+type TestType = 'integration' | 'unit' | undefined
 
 const TEST_STREAM_KEEP_ALIVE_INTERVAL = 1000
 
@@ -247,7 +250,7 @@ export class Tester extends EventEmitter {
 
   private async collectTestFiles(
     cwd: string,
-    type: 'integration' | 'unit' | undefined,
+    type: TestType,
     patterns: Array<string> | undefined
   ): Promise<Array<string>> {
     let folderPattern = '*'
@@ -265,7 +268,8 @@ export class Tester extends EventEmitter {
     }
 
     const testFiles = await Promise.all(
-      patterns.map(async (pattern) => this.collectPatternTestFiles(cwd, folderPattern, pattern))
+      patterns.map(async (pattern) =>
+        this.collectPatternTestFiles(cwd, folderPattern, type, pattern))
     )
 
     return Array.from(new Set(testFiles.flat()))
@@ -274,6 +278,7 @@ export class Tester extends EventEmitter {
   private async collectPatternTestFiles(
     cwd: string,
     folderPattern: string,
+    type: TestType,
     pattern: string
   ): Promise<Array<string>> {
     const globbyOptions = {
@@ -305,7 +310,7 @@ export class Tester extends EventEmitter {
     }
 
     if (targetStat.isDirectory()) {
-      return globby([`**/${folderPattern}/*.test.{ts,tsx,js,jsx}`], {
+      return globby(this.createDirectoryTargetPatterns(folderPattern, type, targetPath), {
         ...globbyOptions,
         cwd: targetPath,
       })
@@ -324,6 +329,30 @@ export class Tester extends EventEmitter {
 
   private isGlobPattern(pattern: string): boolean {
     return /[*?[\]{}]/.test(pattern)
+  }
+
+  private createDirectoryTargetPatterns(
+    folderPattern: string,
+    type: TestType,
+    targetPath: string
+  ): Array<string> {
+    const directTestPattern = '*.test.{ts,tsx,js,jsx}'
+    const nestedTestPattern = `**/${folderPattern}/${directTestPattern}`
+    const targetFolder = basename(targetPath)
+
+    if (type === undefined) {
+      return [directTestPattern, `**/${directTestPattern}`]
+    }
+
+    if (type === 'integration') {
+      return targetFolder === 'integration'
+        ? [directTestPattern, nestedTestPattern]
+        : [nestedTestPattern]
+    }
+
+    return targetFolder === 'integration'
+      ? [nestedTestPattern]
+      : [directTestPattern, nestedTestPattern]
   }
 
   private getProjectIgnorePatterns(): Array<string> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,6 +1070,7 @@ __metadata:
     "@yarnpkg/builder": "npm:4.2.0"
     "@yarnpkg/cli": "npm:4.14.1"
     "@yarnpkg/core": "npm:4.7.0"
+    clipanion: "npm:4.0.0-rc.2"
   peerDependencies:
     "@yarnpkg/cli": "*"
     "@yarnpkg/core": "*"

--- a/yarn/plugin-check/package.json
+++ b/yarn/plugin-check/package.json
@@ -16,6 +16,9 @@
     "prepack": "yarn run build",
     "postpack": "rm -rf dist"
   },
+  "dependencies": {
+    "clipanion": "4.0.0-rc.2"
+  },
   "devDependencies": {
     "@yarnpkg/builder": "4.2.0",
     "@yarnpkg/cli": "4.14.1",

--- a/yarn/plugin-check/sources/check.command.ts
+++ b/yarn/plugin-check/sources/check.command.ts
@@ -1,11 +1,22 @@
 import { BaseCommand } from '@yarnpkg/cli'
+import { Option }      from 'clipanion'
 
 export class CheckCommand extends BaseCommand {
   static paths = [['check']]
 
-  async execute(): Promise<void> {
-    await this.cli.run(['format'])
-    await this.cli.run(['typecheck'])
-    await this.cli.run(['lint'])
+  targets: Array<string> = Option.Rest({ required: 0 })
+
+  async execute(): Promise<number> {
+    let exitCode = 0
+
+    for await (const command of ['format', 'typecheck', 'lint']) {
+      const commandExitCode = await this.cli.run([command, ...this.targets])
+
+      if (commandExitCode) {
+        exitCode = commandExitCode
+      }
+    }
+
+    return exitCode
   }
 }

--- a/yarn/plugin-test/sources/abstract-test.command.test.ts
+++ b/yarn/plugin-test/sources/abstract-test.command.test.ts
@@ -1,0 +1,16 @@
+import assert                  from 'node:assert/strict'
+import { test }                from 'node:test'
+
+import { createProxyTestArgs } from './abstract-test.command.js'
+
+test('should keep proxy test file targets as separate arguments', () => {
+  assert.deepEqual(
+    createProxyTestArgs({
+      files: ['/repo/src/a.test.ts', '/repo/src/b.test.ts'],
+      watch: true,
+      target: '/repo',
+      testReporter: 'tap',
+    }),
+    ['/repo/src/a.test.ts', '/repo/src/b.test.ts', '-w', '-t', '/repo', '--test-reporter=tap']
+  )
+})

--- a/yarn/plugin-test/sources/abstract-test.command.test.ts
+++ b/yarn/plugin-test/sources/abstract-test.command.test.ts
@@ -1,7 +1,7 @@
 import assert                  from 'node:assert/strict'
 import { test }                from 'node:test'
 
-import { createProxyTestArgs } from './abstract-test.command.js'
+import { createProxyTestArgs } from './abstract-test.command.jsx'
 
 test('should keep proxy test file targets as separate arguments', () => {
   assert.deepEqual(

--- a/yarn/plugin-test/sources/abstract-test.command.tsx
+++ b/yarn/plugin-test/sources/abstract-test.command.tsx
@@ -29,6 +29,41 @@ type TestFail = EventData.TestFail
 type TestStderr = EventData.TestStderr
 type TestStdout = EventData.TestStdout
 
+interface ProxyTestArgsOptions {
+  files: Array<string>
+  target?: string
+  testReporter?: string
+  watch: boolean
+}
+
+export const createProxyTestArgs = ({
+  files,
+  target,
+  testReporter,
+  watch,
+}: ProxyTestArgsOptions): Array<string> => {
+  const args: Array<string> = []
+
+  if (files.length) {
+    args.push(...files)
+  }
+
+  if (watch) {
+    args.push('-w')
+  }
+
+  if (target) {
+    args.push('-t')
+    args.push(target)
+  }
+
+  if (testReporter) {
+    args.push(`--test-reporter=${testReporter}`)
+  }
+
+  return args
+}
+
 export abstract class AbstractTestCommand extends BaseCommand {
   static override usage = Command.Usage({
     description: 'Run tests',
@@ -67,25 +102,12 @@ export abstract class AbstractTestCommand extends BaseCommand {
   async executeProxy(type?: 'integration' | 'unit'): Promise<number> {
     const configuration = await Configuration.find(this.context.cwd, this.context.plugins)
     const { project, workspace } = await Project.find(configuration, this.context.cwd)
-
-    const args: Array<string> = []
-
-    if (this.files.length) {
-      args.push(this.files.join(' '))
-    }
-
-    if (this.watch) {
-      args.push('-w')
-    }
-
-    if (workspace) {
-      args.push('-t')
-      args.push(this.context.cwd)
-    }
-
-    if (this.testReporter) {
-      args.push(`--test-reporter=${this.testReporter}`)
-    }
+    const args = createProxyTestArgs({
+      files: this.files,
+      watch: this.watch,
+      target: workspace ? this.context.cwd : undefined,
+      testReporter: this.testReporter,
+    })
 
     const binFolder = await xfs.mktempPromise()
 


### PR DESCRIPTION
## Task
- Close atls/raijin#781

## How to verify
### Before the fix
1. Context: Raijin command receives a directory as an explicit positional target.
Action: Run `yarn format <directory>`, `yarn lint <directory>`, `yarn test unit <directory>`, or `yarn check <directory>`.
Expected result: formatter/linter can pass the directory into file reads, test can return a false green zero-test run, and check rejects the target as an extraneous positional argument.

2. Context: the test command proxies multiple explicit staged test files through the local Yarn runtime.
Action: Run the commit hook path with multiple `*.test.ts` targets.
Expected result: the proxy can join those targets into one invalid path and fail before running tests.

3. Context: an explicit directory target contains glob metacharacters, such as `src/[id]`.
Action: Run a path-scoped command against that literal directory.
Expected result: the command can treat the existing literal directory as a glob and expand the wrong set of files.

### After the fix
1. Context: explicit command target is a file, directory, or missing path.
Action: Run the same path-scoped commands.
Expected result: file targets stay files, directory targets expand to supported files scoped under the directory, missing paths fail with a clear command-level validation error, and `check <target>` forwards the target to format/typecheck/lint.

2. Context: explicit directory target contains glob metacharacters.
Action: Run `format`, `lint`, or `test` against `src/[id]`.
Expected result: the literal directory is resolved first, then command-specific patterns are expanded under that directory.

3. Context: multiple explicit test files are proxied through the local Yarn runtime.
Action: Run `yarn test unit <file-a> <file-b> --test-reporter=tap`.
Expected result: every file remains a separate positional argument.

## Proofs
- `yarn test unit code/code-format/src/formatter.test.ts code/code-lint/src/linter.test.ts code/code-test/src/tester.test.ts yarn/plugin-test/sources/abstract-test.command.test.ts --test-reporter=tap`
- `yarn format code/code-format/src/formatter.ts code/code-format/src/formatter.test.ts code/code-lint/src/linter.ts code/code-lint/src/linter.test.ts code/code-test/src/tester.ts code/code-test/src/tester.test.ts yarn/plugin-check/sources/check.command.ts yarn/plugin-test/sources/abstract-test.command.tsx yarn/plugin-test/sources/abstract-test.command.test.ts`
- `yarn lint code/code-format/src/formatter.ts code/code-format/src/formatter.test.ts code/code-lint/src/linter.ts code/code-lint/src/linter.test.ts code/code-test/src/tester.ts code/code-test/src/tester.test.ts yarn/plugin-check/sources/check.command.ts yarn/plugin-test/sources/abstract-test.command.tsx yarn/plugin-test/sources/abstract-test.command.test.ts`
- `yarn typecheck code/code-format/src/formatter.ts code/code-format/src/formatter.test.ts code/code-lint/src/linter.ts code/code-lint/src/linter.test.ts code/code-test/src/tester.ts code/code-test/src/tester.test.ts yarn/plugin-check/sources/check.command.ts yarn/plugin-test/sources/abstract-test.command.tsx yarn/plugin-test/sources/abstract-test.command.test.ts`
- `yarn lint code/code-lint/src`
- `yarn test unit code/code-test --test-reporter=tap`
- `yarn test unit code/code-lint/src/linter.test.ts code/code-test/src/tester.test.ts --test-reporter=tap`
- `yarn check code/code-test/src`
- `yarn workspace @atls/code-format build`
- `yarn workspace @atls/code-lint build`
- `yarn workspace @atls/code-test build`
- `yarn workspace @atls/yarn-plugin-check build`
- `yarn workspace @atls/yarn-plugin-test build`
- `yarn workspace @atls/yarn-cli build`
- `cmp -s yarn/cli/dist/runtime/yarn.mjs .yarn/releases/yarn.mjs`
- `git diff --check -- ':(exclude).yarn/releases/yarn.mjs'`
- `yarn raijin:check`
