### PR TITLE
test(yarn-plugin-check): cover explicit check targets

### DIFF
--- a/docs/raijin/commands.md
+++ b/docs/raijin/commands.md
@@ -55,6 +55,7 @@ Command map extracted from `yarn/plugin-*` and `@atls/yarn-cli` bundle
 
 - Status: `active`
 - Example: `yarn check`
+- Example: `yarn check yarn/plugin-check/sources`
 - Plugin: `@atls/yarn-plugin-check`
 - Source: `yarn/plugin-check/sources/check.command.ts`
 

--- a/docs/raijin/commands.ru.md
+++ b/docs/raijin/commands.ru.md
@@ -55,6 +55,7 @@
 
 - Статус: `active`
 - Пример: `yarn check`
+- Пример: `yarn check yarn/plugin-check/sources`
 - Плагин: `@atls/yarn-plugin-check`
 - Исходник: `yarn/plugin-check/sources/check.command.ts`
 

--- a/scripts/raijin/generate-artifacts.mjs
+++ b/scripts/raijin/generate-artifacts.mjs
@@ -71,6 +71,10 @@ const DETAILED_GROUPS = new Set(WORKSPACE_GROUP_ORDER.filter((group) => group !=
 const COVER_IMAGE_URL =
   'https://github.com/user-attachments/assets/ac98b900-ee3c-4ea8-a081-e83a1f5f3282'
 
+const COMMAND_EXAMPLES = {
+  check: ['yarn check', 'yarn check yarn/plugin-check/sources'],
+}
+
 const walkFiles = (dirPath, predicate, output = []) => {
   if (!fs.existsSync(dirPath)) return output
 
@@ -729,9 +733,11 @@ const renderCommandCard = (command, language) => {
   ]
 
   if (command.status === 'active') {
-    lines.push(
-      isRu ? `- Пример: \`yarn ${command.command}\`` : `- Example: \`yarn ${command.command}\``
-    )
+    const examples = COMMAND_EXAMPLES[command.command] ?? [`yarn ${command.command}`]
+
+    examples.forEach((example) => {
+      lines.push(isRu ? `- Пример: \`${example}\`` : `- Example: \`${example}\``)
+    })
   } else {
     lines.push(
       isRu

--- a/yarn/plugin-check/sources/check.command.test.ts
+++ b/yarn/plugin-check/sources/check.command.test.ts
@@ -1,0 +1,54 @@
+import assert           from 'node:assert/strict'
+import test             from 'node:test'
+
+import { CheckCommand } from './check.command.js'
+
+const runCheckCommand = async (
+  targets: Array<string>,
+  exitCodes: Array<number> = [0, 0, 0]
+): Promise<{ exitCode: number; commands: Array<Array<string>> }> => {
+  const commands: Array<Array<string>> = []
+  const command = Object.assign(Object.create(CheckCommand.prototype), {
+    targets,
+    cli: {
+      run: async (args: Array<string>) => {
+        commands.push(args)
+
+        return exitCodes[commands.length - 1] ?? 0
+      },
+    },
+  }) as CheckCommand
+
+  const exitCode = await command.execute()
+
+  return { exitCode, commands }
+}
+
+test('should run full check sequence without explicit targets', async () => {
+  const { exitCode, commands } = await runCheckCommand([])
+
+  assert.equal(exitCode, 0)
+  assert.deepEqual(commands, [['format'], ['typecheck'], ['lint']])
+})
+
+test('should forward explicit targets to every check command', async () => {
+  const { exitCode, commands } = await runCheckCommand(['yarn/plugin-check/sources'])
+
+  assert.equal(exitCode, 0)
+  assert.deepEqual(commands, [
+    ['format', 'yarn/plugin-check/sources'],
+    ['typecheck', 'yarn/plugin-check/sources'],
+    ['lint', 'yarn/plugin-check/sources'],
+  ])
+})
+
+test('should preserve non-zero exit code after running every check command', async () => {
+  const { exitCode, commands } = await runCheckCommand(['yarn/plugin-check/sources'], [0, 1, 0])
+
+  assert.equal(exitCode, 1)
+  assert.deepEqual(commands, [
+    ['format', 'yarn/plugin-check/sources'],
+    ['typecheck', 'yarn/plugin-check/sources'],
+    ['lint', 'yarn/plugin-check/sources'],
+  ])
+})


### PR DESCRIPTION
## Task

- Close atls/raijin#779

## How to verify

### Before the fix

1. Context: `yarn check` command-level coverage
   Action: run command tests around the no-target and explicit-target routes
   Expected result: the targeted forwarding route is not covered by tests or generated command docs

### After the fix

1. Context: `yarn check` command-level coverage
   Action: `yarn test unit yarn/plugin-check/sources/check.command.test.ts --test-reporter=tap`
   Expected result: no-target, targeted, and non-zero exit-code routes pass

2. Context: explicit target route
   Action: `yarn check yarn/plugin-check/sources/check.command.test.ts`
   Expected result: `check` forwards the explicit target through `format`, `typecheck`, and `lint`

3. Context: generated command reference
   Action: `yarn raijin:generate` and `yarn raijin:check:drift`
   Expected result: generated docs mention `yarn check yarn/plugin-check/sources` and drift check is clean

## Proofs

- `yarn test unit yarn/plugin-check/sources/check.command.test.ts --test-reporter=tap`

```text
ok 1 should run full check sequence without explicit targets
ok 2 should forward explicit targets to every check command
ok 3 should preserve non-zero exit code after running every check command
```

- `yarn check yarn/plugin-check/sources/check.command.test.ts`

```text
exit 0
```

- `yarn raijin:check:drift`

```text
Generated raijin artifacts: 38 commands 67 workspace packages (active: 37, inactive: 1)
```
