### PR TITLE
feat(yarn-plugin-image): use buildpack channel defaults

### DIFF
--- a/docs/raijin/commands.md
+++ b/docs/raijin/commands.md
@@ -247,6 +247,10 @@ Command map extracted from `yarn/plugin-*` and `@atls/yarn-cli` bundle
 
 - Status: `active`
 - Example: `yarn image pack`
+- Contract: `packConfiguration` defaults to `ghcr.io/atls/buildpack-yarn-workspace:24`.
+- Contract: `packConfiguration.builderTag` selects the supported Node/buildpack channel.
+- Contract: `packConfiguration.buildpackVersion` pins an immutable buildpack tag for rollback.
+- Contract: `packConfiguration.buildpack` overrides the full buildpack reference.
 - Plugin: `@atls/yarn-plugin-image`
 - Source: `yarn/plugin-image/sources/image-pack.command.ts`
 

--- a/docs/raijin/commands.ru.md
+++ b/docs/raijin/commands.ru.md
@@ -247,6 +247,10 @@
 
 - Статус: `active`
 - Пример: `yarn image pack`
+- Контракт: `packConfiguration` по умолчанию использует `ghcr.io/atls/buildpack-yarn-workspace:24`.
+- Контракт: `packConfiguration.builderTag` выбирает поддерживаемый Node/buildpack-канал.
+- Контракт: `packConfiguration.buildpackVersion` фиксирует неизменяемый buildpack tag для rollback.
+- Контракт: `packConfiguration.buildpack` переопределяет полную buildpack-ссылку.
 - Плагин: `@atls/yarn-plugin-image`
 - Исходник: `yarn/plugin-image/sources/image-pack.command.ts`
 

--- a/scripts/raijin/generate-artifacts.mjs
+++ b/scripts/raijin/generate-artifacts.mjs
@@ -75,6 +75,23 @@ const COMMAND_EXAMPLES = {
   check: ['yarn check', 'yarn check yarn/plugin-check/sources'],
 }
 
+const COMMAND_NOTES = {
+  'image pack': {
+    en: [
+      '`packConfiguration` defaults to `ghcr.io/atls/buildpack-yarn-workspace:24`.',
+      '`packConfiguration.builderTag` selects the supported Node/buildpack channel.',
+      '`packConfiguration.buildpackVersion` pins an immutable buildpack tag for rollback.',
+      '`packConfiguration.buildpack` overrides the full buildpack reference.',
+    ],
+    ru: [
+      '`packConfiguration` по умолчанию использует `ghcr.io/atls/buildpack-yarn-workspace:24`.',
+      '`packConfiguration.builderTag` выбирает поддерживаемый Node/buildpack-канал.',
+      '`packConfiguration.buildpackVersion` фиксирует неизменяемый buildpack tag для rollback.',
+      '`packConfiguration.buildpack` переопределяет полную buildpack-ссылку.',
+    ],
+  },
+}
+
 const walkFiles = (dirPath, predicate, output = []) => {
   if (!fs.existsSync(dirPath)) return output
 
@@ -745,6 +762,12 @@ const renderCommandCard = (command, language) => {
         : '- Example: unavailable for inactive command'
     )
   }
+
+  const notes = COMMAND_NOTES[command.command]?.[isRu ? 'ru' : 'en']
+
+  notes?.forEach((note) => {
+    lines.push(isRu ? `- Контракт: ${note}` : `- Contract: ${note}`)
+  })
 
   lines.push(isRu ? `- Плагин: \`${command.plugin}\`` : `- Plugin: \`${command.plugin}\``)
   lines.push(isRu ? `- Исходник: \`${command.source}\`` : `- Source: \`${command.source}\``)

--- a/yarn/plugin-image/sources/image-pack.utils.ts
+++ b/yarn/plugin-image/sources/image-pack.utils.ts
@@ -1,9 +1,8 @@
 import { arch } from 'node:os'
 
 const DEFAULT_BUILDER_TAG = '24'
-const DEFAULT_BUILDPACK_VERSION = '0.1.3'
 const DEFAULT_BUILDER_IMAGE = 'atlantislab/builder-base'
-const DEFAULT_BUILDPACK_IMAGE = 'ghcr.io/atls/buildpack-yarn-workspace-start'
+const DEFAULT_BUILDPACK_IMAGE = 'ghcr.io/atls/buildpack-yarn-workspace'
 const DEFAULT_MATERIALIZATION_OS = 'linux'
 
 export interface ImagePackConfiguration {
@@ -23,13 +22,14 @@ export const resolveBuildpackReference = ({
   buildpack,
   buildpackImage,
   buildpackVersion,
+  builderTag,
 }: ImagePackConfiguration): string => {
   if (buildpack) {
     return buildpack
   }
 
   return `${buildpackImage ?? DEFAULT_BUILDPACK_IMAGE}:${
-    buildpackVersion ?? DEFAULT_BUILDPACK_VERSION
+    buildpackVersion ?? builderTag ?? DEFAULT_BUILDER_TAG
   }`
 }
 

--- a/yarn/plugin-image/sources/tests/image-pack.utils.test.ts
+++ b/yarn/plugin-image/sources/tests/image-pack.utils.test.ts
@@ -4,16 +4,25 @@ import { test }                      from 'node:test'
 import { resolveBuildpackReference } from '../image-pack.utils.js'
 import { resolveBuilderReference }   from '../image-pack.utils.js'
 
-test('should use start-image buildpack by default', () => {
-  assert.equal(resolveBuildpackReference({}), 'ghcr.io/atls/buildpack-yarn-workspace-start:0.1.3')
+test('should use buildpack channel for the default Node line', () => {
+  assert.equal(resolveBuildpackReference({}), 'ghcr.io/atls/buildpack-yarn-workspace:24')
 })
 
-test('should keep buildpack version override on start-image buildpack', () => {
+test('should use selected Node line as buildpack channel', () => {
+  assert.equal(
+    resolveBuildpackReference({
+      builderTag: '26',
+    }),
+    'ghcr.io/atls/buildpack-yarn-workspace:26'
+  )
+})
+
+test('should keep buildpack version override as immutable semver pin', () => {
   assert.equal(
     resolveBuildpackReference({
       buildpackVersion: '0.1.3',
     }),
-    'ghcr.io/atls/buildpack-yarn-workspace-start:0.1.3'
+    'ghcr.io/atls/buildpack-yarn-workspace:0.1.3'
   )
 })
 


### PR DESCRIPTION
## Task
- Close atls/raijin#649

## How to verify
### Main scenario
1. Context: `yarn image pack` buildpack resolver
Action: run `yarn test unit yarn/plugin-image/sources/tests/image-pack.utils.test.ts --test-reporter=tap`
Expected result: default buildpack resolves to `ghcr.io/atls/buildpack-yarn-workspace:24`, `builderTag` selects the buildpack channel, `buildpackVersion` keeps the semver pin path, and `buildpack` keeps the full reference override.

### Additional scenario
1. Context: generated command docs and runtime bundle
Action: run `yarn raijin:generate`, `yarn workspace @atls/yarn-plugin-image build`, `yarn workspace @atls/yarn-cli build`, and `yarn raijin:check`
Expected result: generated docs describe the channel and override contract, `.yarn/releases/yarn.mjs` matches the built runtime, and Raijin checks pass.

## Proofs
- `yarn test unit yarn/plugin-image/sources/tests/image-pack.utils.test.ts --test-reporter=tap`
```text
1..6
# tests 6
# pass 6
# fail 0
```
- `yarn check yarn/plugin-image/sources/image-pack.utils.ts yarn/plugin-image/sources/tests/image-pack.utils.test.ts scripts/raijin/generate-artifacts.mjs`
```text
exit 0
```
- `docker manifest inspect ghcr.io/atls/buildpack-yarn-workspace:24`, `ghcr.io/atls/buildpack-yarn-workspace:26`, `atlantislab/builder-base:24`, `atlantislab/builder-base:26`
```text
OK
```
- `yarn raijin:check`
```text
Schematic smoke passed
```

