### PR TITLE
fix(code-schematics): replace schematic template url source

### DIFF
--- a/code/code-schematics/src/schematic/sources/generate-common.source.ts
+++ b/code/code-schematics/src/schematic/sources/generate-common.source.ts
@@ -1,13 +1,14 @@
-import type { Source } from '@angular-devkit/schematics'
+import type { Source }    from '@angular-devkit/schematics'
 
-import { strings }     from '@angular-devkit/core'
-import { apply }       from '@angular-devkit/schematics'
-import { template }    from '@angular-devkit/schematics'
-import { move }        from '@angular-devkit/schematics'
-import { url }         from '@angular-devkit/schematics'
+import { strings }        from '@angular-devkit/core'
+import { apply }          from '@angular-devkit/schematics'
+import { template }       from '@angular-devkit/schematics'
+import { move }           from '@angular-devkit/schematics'
+
+import { templateSource } from './template-source.js'
 
 export const generateCommonSource = (options: Record<string, string>): Source =>
-  apply(url('../templates/common'), [
+  apply(templateSource('../templates/common'), [
     template({
       ...strings,
       ...options,

--- a/code/code-schematics/src/schematic/sources/generate-project-specific.source.ts
+++ b/code/code-schematics/src/schematic/sources/generate-project-specific.source.ts
@@ -1,13 +1,14 @@
-import type { Source }  from '@angular-devkit/schematics'
+import type { Source }    from '@angular-devkit/schematics'
 
-import { readFileSync } from 'node:fs'
-import { join }         from 'node:path'
+import { readFileSync }   from 'node:fs'
+import { join }           from 'node:path'
 
-import { strings }      from '@angular-devkit/core'
-import { apply }        from '@angular-devkit/schematics'
-import { url }          from '@angular-devkit/schematics'
-import { template }     from '@angular-devkit/schematics'
-import { move }         from '@angular-devkit/schematics'
+import { strings }        from '@angular-devkit/core'
+import { apply }          from '@angular-devkit/schematics'
+import { template }       from '@angular-devkit/schematics'
+import { move }           from '@angular-devkit/schematics'
+
+import { templateSource } from './template-source.js'
 
 const templateTypes: Record<string, string> = {
   library: 'libraries',
@@ -21,7 +22,7 @@ export const generateProjectSpecificSource = (options: Record<string, string>): 
   )
   const templateType = templateTypes[options.type] ?? options.type
 
-  return apply(url(join('../templates', templateType)), [
+  return apply(templateSource(join('../templates', templateType)), [
     template({
       ...strings,
       ...options,

--- a/code/code-schematics/src/schematic/sources/index.ts
+++ b/code/code-schematics/src/schematic/sources/index.ts
@@ -1,2 +1,3 @@
 export * from './generate-common.source.js'
 export * from './generate-project-specific.source.js'
+export * from './template-source.js'

--- a/code/code-schematics/src/schematic/sources/template-source.test.ts
+++ b/code/code-schematics/src/schematic/sources/template-source.test.ts
@@ -1,0 +1,45 @@
+import type { SchematicContext } from '@angular-devkit/schematics'
+
+import assert                    from 'node:assert/strict'
+import { mkdir }                 from 'node:fs/promises'
+import { mkdtemp }               from 'node:fs/promises'
+import { rm }                    from 'node:fs/promises'
+import { writeFile }             from 'node:fs/promises'
+import { tmpdir }                from 'node:os'
+import { join }                  from 'node:path'
+import { test }                  from 'node:test'
+
+import { callSource }            from '@angular-devkit/schematics'
+import { lastValueFrom }         from 'rxjs'
+
+import { templateSource }        from './template-source.js'
+
+const createSchematicContext = (schematicPath: string): SchematicContext =>
+  ({
+    schematic: {
+      description: {
+        path: schematicPath,
+      },
+    },
+  }) as unknown as SchematicContext
+
+test('should create source tree from template path relative to schematic path', async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), 'schematic-template-source-'))
+  const templateDir = join(tmpDir, 'templates/common')
+
+  try {
+    await mkdir(templateDir, { recursive: true })
+    await writeFile(join(templateDir, '__dot__prettierrc.mjs'), 'export default {}\n')
+
+    const tree = await lastValueFrom(
+      callSource(
+        templateSource('../templates/common'),
+        createSchematicContext(join(tmpDir, 'project'))
+      )
+    )
+
+    assert.equal(tree.readText('/__dot__prettierrc.mjs'), 'export default {}\n')
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true })
+  }
+})

--- a/code/code-schematics/src/schematic/sources/template-source.ts
+++ b/code/code-schematics/src/schematic/sources/template-source.ts
@@ -1,0 +1,25 @@
+import type { Source }    from '@angular-devkit/schematics'
+
+import { resolve }        from 'node:path'
+
+import { NodeJsSyncHost } from '@angular-devkit/core/node'
+import { HostCreateTree } from '@angular-devkit/schematics'
+import { normalize }      from '@angular-devkit/core'
+import { virtualFs }      from '@angular-devkit/core'
+
+type FileSystemSchematicDescription = {
+  path?: string
+}
+
+export const templateSource = (templatePath: string): Source =>
+  (context) => {
+    const { path: schematicPath } = context.schematic.description as FileSystemSchematicDescription
+
+    if (schematicPath === undefined) {
+      throw new Error('Cannot resolve schematic template source without schematic path')
+    }
+
+    const root = normalize(resolve(schematicPath, templatePath))
+
+    return new HostCreateTree(new virtualFs.ScopedHost(new NodeJsSyncHost(), root))
+  }


### PR DESCRIPTION
## Task

- Close atls/raijin#764

## How to verify

### Before the fix

1. Context: generated Raijin schematic factory loads templates through `@angular-devkit/schematics` `url()`.
   Action: run schematic smoke with `NODE_OPTIONS=--trace-deprecation`.
   Expected result: Node reports `DEP0169 url.parse()` from schematic template loading.

### After the fix

1. Context: generated Raijin schematic factory loads templates through the owned `templateSource(...)` source.
   Action: run `NODE_OPTIONS=--trace-deprecation yarn raijin:check`.
   Expected result: Raijin check and schematic smoke complete without `DEP0169 url.parse()` warnings.

## Proofs

- `NODE_OPTIONS=--trace-deprecation yarn workspace @atls/code-schematics smoke:schematic`

```text
Schematic factory build succeeded
Schematic smoke passed
```

- `NODE_OPTIONS=--trace-deprecation yarn raijin:check`

```text
Generated raijin artifacts: 38 commands 67 workspace packages
Localization sync check passed
Deterministic smoke passed (8 cases)
Schematic factory build succeeded
Schematic smoke passed
```

- Local validation

```text
yarn format <changed schematic source files>
yarn typecheck <changed schematic source files>
yarn lint <changed schematic source files>
yarn test unit code/code-schematics/src/schematic/sources/template-source.test.ts --test-reporter=tap
yarn workspace @atls/code-schematics build
yarn workspace @atls/code-schematics pack --dry-run --json
yarn workspace @atls/yarn-cli build
cmp -s yarn/cli/dist/runtime/yarn.mjs .yarn/releases/yarn.mjs
git diff --check -- . :!.yarn/releases/yarn.mjs :!code/code-schematics/dist
yarn check
```
