### PR TITLE
test(yarn-plugin-release): lock GitHub-native release boundary

### DIFF
--- a/yarn/plugin-release/sources/tests/release-create.command.test.ts
+++ b/yarn/plugin-release/sources/tests/release-create.command.test.ts
@@ -3,6 +3,7 @@ import type { PortablePath }                    from '@yarnpkg/fslib'
 import assert                                   from 'node:assert/strict'
 import { Buffer }                               from 'node:buffer'
 import { mkdtemp }                              from 'node:fs/promises'
+import { readFile }                             from 'node:fs/promises'
 import { writeFile }                            from 'node:fs/promises'
 import { tmpdir }                               from 'node:os'
 import { join }                                 from 'node:path'
@@ -18,6 +19,18 @@ import { isReleaseAlreadyExistsError }          from '../release-create.command.
 import { parseGitHubReleaseTagVersion }         from '../release-create.command.js'
 import { readYarnRuntimePackageManager }        from '../release-create.command.js'
 import { selectPreviousGitHubReleaseTagName }   from '../release-create.command.js'
+
+test('should keep release creation on the GitHub-native dependency boundary', async () => {
+  const manifest = JSON.parse(
+    await readFile(new URL('../../package.json', import.meta.url), 'utf-8')
+  ) as {
+    dependencies?: Record<string, string>
+  }
+
+  assert.ok(manifest.dependencies)
+  assert.equal(manifest.dependencies['@atls/code-github'], 'workspace:*')
+  assert.equal(manifest.dependencies['@atls/code-changelog'], undefined)
+})
 
 test('should create releases with GitHub generated release notes', () => {
   assert.deepEqual(


### PR DESCRIPTION
## Task
- Close atls/raijin#744

## How to verify
### Main scenario
1. Context: release create regression tests
Action: run `yarn test unit yarn/plugin-release/sources/tests/release-create.command.test.ts --test-reporter=tap`
Expected result: the GitHub-native dependency boundary test passes with the existing release create regressions.

### Additional scenario
1. Context: repository-managed validation for release create
Action: run targeted typecheck, lint, format, plugin build, `yarn check yarn/plugin-release/sources/tests/release-create.command.test.ts`, `git diff --check -- . ':!.yarn/releases/yarn.mjs'`, and `yarn raijin:check`
Expected result: all checks pass.

## Proofs
- `yarn test unit yarn/plugin-release/sources/tests/release-create.command.test.ts --test-reporter=tap`
```text
1..20
# pass 20
# fail 0
```
- `yarn workspace @atls/yarn-plugin-release build`
```text
Done building @yarnpkg/plugin-release
```
- `yarn check yarn/plugin-release/sources/tests/release-create.command.test.ts` and `yarn raijin:check`
```text
passed
```
