### PR TITLE
fix(yarn-pack-utils): copy patch files

### DIFF
--- a/yarn/pack-utils/src/copy.utils.ts
+++ b/yarn/pack-utils/src/copy.utils.ts
@@ -1,5 +1,6 @@
 import type { Workspace }    from '@yarnpkg/core'
 import type { Cache }        from '@yarnpkg/core'
+import type { Descriptor }   from '@yarnpkg/core'
 import type { Project }      from '@yarnpkg/core'
 import type { Report }       from '@yarnpkg/core'
 import type { PortablePath } from '@yarnpkg/fslib'
@@ -63,6 +64,25 @@ export const copyPlugins = async (
 
 const BUILTIN_REGEXP = /^builtin<([^>]+)>$/
 
+function* getPatchDescriptorSources(
+  project: Project,
+  workspace: Workspace
+): Generator<[Descriptor, Workspace]> {
+  for (const descriptor of workspace.manifest.dependencies.values()) {
+    yield [descriptor, workspace]
+  }
+
+  for (const descriptor of workspace.manifest.peerDependencies.values()) {
+    yield [descriptor, workspace]
+  }
+
+  for (const resolution of project.topLevelWorkspace.manifest.resolutions) {
+    const ident = structUtils.parseIdent(resolution.pattern.descriptor.fullName)
+
+    yield [structUtils.makeDescriptor(ident, resolution.reference), project.topLevelWorkspace]
+  }
+}
+
 export const copyPatchFiles = async (
   project: Project,
   workspace: Workspace,
@@ -70,17 +90,14 @@ export const copyPatchFiles = async (
   report: Report
 ): Promise<void> => {
   const copiedPaths = new Map<PortablePath, PortablePath>()
+  const copyOperations = new Array<{ dest: PortablePath; src: PortablePath }>()
 
-  for await (const descriptor of project.storedDescriptors.values()) {
-    const resolvedDescriptor = structUtils.isVirtualDescriptor(descriptor)
-      ? structUtils.devirtualizeDescriptor(descriptor)
-      : descriptor
+  for (const [descriptor, ownerWorkspace] of getPatchDescriptorSources(project, workspace)) {
+    if (!patchUtils.isPatchDescriptor(descriptor)) continue
 
-    if (!patchUtils.isPatchDescriptor(resolvedDescriptor)) continue
+    const { patchPaths } = patchUtils.parseDescriptor(descriptor)
 
-    const { parentLocator, patchPaths } = patchUtils.parseDescriptor(resolvedDescriptor)
-
-    for await (const rawPath of patchPaths) {
+    for (const rawPath of patchPaths) {
       const flagIndex = rawPath.lastIndexOf('!')
       const path = (flagIndex === -1 ? rawPath : rawPath.slice(flagIndex + 1)) as PortablePath
 
@@ -95,14 +112,7 @@ export const copyPatchFiles = async (
         sourceCwd = project.cwd
         src = ppath.resolve(sourceCwd, path.slice(2) as PortablePath)
       } else {
-        if (parentLocator === null) continue
-
-        const parentWorkspace = project.tryWorkspaceByLocator(parentLocator)
-
-        if (!parentWorkspace) continue
-        if (parentWorkspace !== project.topLevelWorkspace && parentWorkspace !== workspace) continue
-
-        sourceCwd = parentWorkspace.cwd
+        sourceCwd = ownerWorkspace.cwd
         src = ppath.resolve(sourceCwd, path)
       }
 
@@ -126,11 +136,16 @@ export const copyPatchFiles = async (
 
       report.reportInfo(null, relativePath)
 
-      await xfs.mkdirpPromise(ppath.dirname(dest))
-
-      await xfs.copyFilePromise(src, dest)
+      copyOperations.push({ dest, src })
     }
   }
+
+  await Promise.all(
+    copyOperations.map(async ({ dest, src }) => {
+      await xfs.mkdirpPromise(ppath.dirname(dest))
+      await xfs.copyFilePromise(src, dest)
+    })
+  )
 }
 
 export const copyRcFile = async (

--- a/yarn/pack-utils/src/copy.utils.ts
+++ b/yarn/pack-utils/src/copy.utils.ts
@@ -106,7 +106,9 @@ export const copyProtocolFiles = async (
           throw new Error(`Protocol path ${path} requires a parent locator`)
         }
 
-        const parentWorkspace = project.getWorkspaceByLocator(parentLocator)
+        const parentWorkspace = project.tryWorkspaceByLocator(parentLocator)
+
+        if (!parentWorkspace) continue
 
         relativePath =
           parentWorkspace === workspace ? path : ppath.join(parentWorkspace.relativeCwd, path)

--- a/yarn/pack-utils/src/copy.utils.ts
+++ b/yarn/pack-utils/src/copy.utils.ts
@@ -67,6 +67,7 @@ const BUILTIN_REGEXP = /^builtin<([^>]+)>$/
 
 export const copyProtocolFiles = async (
   project: Project,
+  workspace: Workspace,
   destination: PortablePath,
   report: Report,
   parseDescriptor: (
@@ -107,7 +108,8 @@ export const copyProtocolFiles = async (
 
         const parentWorkspace = project.getWorkspaceByLocator(parentLocator)
 
-        relativePath = ppath.join(parentWorkspace.relativeCwd, path)
+        relativePath =
+          parentWorkspace === workspace ? path : ppath.join(parentWorkspace.relativeCwd, path)
         src = ppath.join(parentWorkspace.cwd, path)
       }
 

--- a/yarn/pack-utils/src/copy.utils.ts
+++ b/yarn/pack-utils/src/copy.utils.ts
@@ -71,7 +71,7 @@ export const copyProtocolFiles = async (
   report: Report,
   parseDescriptor: (
     descriptor: Descriptor
-  ) => { parentLocator: Locator; paths: Array<PortablePath> } | undefined
+  ) => { parentLocator: Locator | null; paths: Array<PortablePath> } | undefined
 ): Promise<void> => {
   const copiedPaths = new Set<string>()
 
@@ -86,20 +86,35 @@ export const copyProtocolFiles = async (
 
     const { parentLocator, paths } = parsed
 
-    for await (const path of paths) {
-      if (BUILTIN_REGEXP.test(path)) continue
+    for await (const rawPath of paths) {
+      const flagIndex = rawPath.lastIndexOf('!')
+      const path = (flagIndex === -1 ? rawPath : rawPath.slice(flagIndex + 1)) as PortablePath
 
+      if (BUILTIN_REGEXP.test(path)) continue
       if (ppath.isAbsolute(path)) continue
 
-      const parentWorkspace = project.getWorkspaceByLocator(parentLocator)
+      const isProjectPath = path.startsWith('~/')
+      let relativePath: PortablePath
+      let src: PortablePath
 
-      const relativePath = ppath.join(parentWorkspace.relativeCwd, path)
+      if (isProjectPath) {
+        relativePath = path.slice(2) as PortablePath
+        src = ppath.join(project.cwd, relativePath)
+      } else {
+        if (parentLocator === null) {
+          throw new Error(`Protocol path ${path} requires a parent locator`)
+        }
+
+        const parentWorkspace = project.getWorkspaceByLocator(parentLocator)
+
+        relativePath = ppath.join(parentWorkspace.relativeCwd, path)
+        src = ppath.join(parentWorkspace.cwd, path)
+      }
 
       if (copiedPaths.has(relativePath)) continue
 
       copiedPaths.add(relativePath)
 
-      const src = ppath.join(parentWorkspace.cwd, path)
       const dest = ppath.join(destination, relativePath)
 
       report.reportInfo(null, relativePath)

--- a/yarn/pack-utils/src/copy.utils.ts
+++ b/yarn/pack-utils/src/copy.utils.ts
@@ -1,15 +1,17 @@
-import type { Workspace }    from '@yarnpkg/core'
-import type { Cache }        from '@yarnpkg/core'
-import type { Descriptor }   from '@yarnpkg/core'
-import type { Project }      from '@yarnpkg/core'
-import type { Report }       from '@yarnpkg/core'
-import type { PortablePath } from '@yarnpkg/fslib'
+import type { Workspace }                 from '@yarnpkg/core'
+import type { Cache }                     from '@yarnpkg/core'
+import type { Project }                   from '@yarnpkg/core'
+import type { Report }                    from '@yarnpkg/core'
+import type { PortablePath }              from '@yarnpkg/fslib'
 
-import { Manifest }          from '@yarnpkg/core'
-import { structUtils }       from '@yarnpkg/core'
-import { xfs }               from '@yarnpkg/fslib'
-import { ppath }             from '@yarnpkg/fslib'
-import { patchUtils }        from '@yarnpkg/plugin-patch'
+import { Manifest }                       from '@yarnpkg/core'
+import { xfs }                            from '@yarnpkg/fslib'
+import { ppath }                          from '@yarnpkg/fslib'
+
+import { getProjectResolutionPatchPaths } from './patch-files/paths.js'
+import { getWorkspacePatchPaths }         from './patch-files/paths.js'
+import { resolvePatchPath }               from './patch-files/paths.js'
+import { getRequiredWorkspaces }          from './workspaces.utils.js'
 
 export const copyCacheMarkedFiles = async (
   project: Project,
@@ -62,81 +64,38 @@ export const copyPlugins = async (
   }
 }
 
-const BUILTIN_REGEXP = /^builtin<([^>]+)>$/
-
-function* getPatchDescriptorSources(
-  project: Project,
-  workspace: Workspace
-): Generator<[Descriptor, Workspace]> {
-  for (const descriptor of workspace.manifest.dependencies.values()) {
-    yield [descriptor, workspace]
-  }
-
-  for (const descriptor of workspace.manifest.peerDependencies.values()) {
-    yield [descriptor, workspace]
-  }
-
-  for (const resolution of project.topLevelWorkspace.manifest.resolutions) {
-    const ident = structUtils.parseIdent(resolution.pattern.descriptor.fullName)
-
-    yield [structUtils.makeDescriptor(ident, resolution.reference), project.topLevelWorkspace]
-  }
-}
-
 export const copyPatchFiles = async (
   project: Project,
   workspace: Workspace,
   destination: PortablePath,
   report: Report
 ): Promise<void> => {
-  const copiedPaths = new Map<PortablePath, PortablePath>()
+  const copiedPaths = new Set<PortablePath>()
   const copyOperations = new Array<{ dest: PortablePath; src: PortablePath }>()
 
-  for (const [descriptor, ownerWorkspace] of getPatchDescriptorSources(project, workspace)) {
-    if (!patchUtils.isPatchDescriptor(descriptor)) continue
+  const registerPatchFile = (path: PortablePath): void => {
+    const { relativePath, src } = resolvePatchPath(project.cwd, path, 'standalone workspace')
 
-    const { patchPaths } = patchUtils.parseDescriptor(descriptor)
+    if (copiedPaths.has(relativePath)) return
 
-    for (const rawPath of patchPaths) {
-      const flagIndex = rawPath.lastIndexOf('!')
-      const path = (flagIndex === -1 ? rawPath : rawPath.slice(flagIndex + 1)) as PortablePath
+    copiedPaths.add(relativePath)
 
-      if (BUILTIN_REGEXP.test(path)) continue
-      if (ppath.isAbsolute(path)) continue
+    const dest = ppath.join(destination, relativePath)
 
-      const isProjectPath = path.startsWith('~/')
-      let sourceCwd: PortablePath
-      let src: PortablePath
+    report.reportInfo(null, relativePath)
 
-      if (isProjectPath) {
-        sourceCwd = project.cwd
-        src = ppath.resolve(sourceCwd, path.slice(2) as PortablePath)
-      } else {
-        sourceCwd = ownerWorkspace.cwd
-        src = ppath.resolve(sourceCwd, path)
-      }
+    copyOperations.push({ dest, src })
+  }
 
-      const relativePath = ppath.contains(sourceCwd, src)
+  for (const path of getProjectResolutionPatchPaths(project)) {
+    registerPatchFile(path.startsWith('~/') ? (path.slice(2) as PortablePath) : path)
+  }
 
-      if (relativePath === null) {
-        throw new Error(`Patch path ${path} resolves outside the standalone workspace`)
-      }
+  for (const requiredWorkspace of getRequiredWorkspaces(project, [workspace], true)) {
+    for (const path of getWorkspacePatchPaths(requiredWorkspace)) {
+      if (!path.startsWith('~/')) continue
 
-      const previousSrc = copiedPaths.get(relativePath)
-
-      if (previousSrc === src) continue
-
-      if (previousSrc) {
-        throw new Error(`Patch files ${previousSrc} and ${src} resolve to ${relativePath}`)
-      }
-
-      copiedPaths.set(relativePath, src)
-
-      const dest = ppath.join(destination, relativePath)
-
-      report.reportInfo(null, relativePath)
-
-      copyOperations.push({ dest, src })
+      registerPatchFile(path.slice(2) as PortablePath)
     }
   }
 

--- a/yarn/pack-utils/src/copy.utils.ts
+++ b/yarn/pack-utils/src/copy.utils.ts
@@ -2,14 +2,13 @@ import type { Workspace }    from '@yarnpkg/core'
 import type { Cache }        from '@yarnpkg/core'
 import type { Project }      from '@yarnpkg/core'
 import type { Report }       from '@yarnpkg/core'
-import type { Descriptor }   from '@yarnpkg/core'
-import type { Locator }      from '@yarnpkg/core'
 import type { PortablePath } from '@yarnpkg/fslib'
 
 import { Manifest }          from '@yarnpkg/core'
 import { structUtils }       from '@yarnpkg/core'
 import { xfs }               from '@yarnpkg/fslib'
 import { ppath }             from '@yarnpkg/fslib'
+import { patchUtils }        from '@yarnpkg/plugin-patch'
 
 export const copyCacheMarkedFiles = async (
   project: Project,
@@ -62,32 +61,26 @@ export const copyPlugins = async (
   }
 }
 
-// https://github.com/yarnpkg/berry/blob/d38d573/packages/plugin-patch/sources/patchUtils.js#L10
 const BUILTIN_REGEXP = /^builtin<([^>]+)>$/
 
-export const copyProtocolFiles = async (
+export const copyPatchFiles = async (
   project: Project,
   workspace: Workspace,
   destination: PortablePath,
-  report: Report,
-  parseDescriptor: (
-    descriptor: Descriptor
-  ) => { parentLocator: Locator | null; paths: Array<PortablePath> } | undefined
+  report: Report
 ): Promise<void> => {
-  const copiedPaths = new Set<string>()
+  const copiedPaths = new Map<PortablePath, PortablePath>()
 
   for await (const descriptor of project.storedDescriptors.values()) {
     const resolvedDescriptor = structUtils.isVirtualDescriptor(descriptor)
       ? structUtils.devirtualizeDescriptor(descriptor)
       : descriptor
 
-    const parsed = parseDescriptor(resolvedDescriptor)
+    if (!patchUtils.isPatchDescriptor(resolvedDescriptor)) continue
 
-    if (!parsed) continue
+    const { parentLocator, patchPaths } = patchUtils.parseDescriptor(resolvedDescriptor)
 
-    const { parentLocator, paths } = parsed
-
-    for await (const rawPath of paths) {
+    for await (const rawPath of patchPaths) {
       const flagIndex = rawPath.lastIndexOf('!')
       const path = (flagIndex === -1 ? rawPath : rawPath.slice(flagIndex + 1)) as PortablePath
 
@@ -95,29 +88,39 @@ export const copyProtocolFiles = async (
       if (ppath.isAbsolute(path)) continue
 
       const isProjectPath = path.startsWith('~/')
-      let relativePath: PortablePath
+      let sourceCwd: PortablePath
       let src: PortablePath
 
       if (isProjectPath) {
-        relativePath = path.slice(2) as PortablePath
-        src = ppath.join(project.cwd, relativePath)
+        sourceCwd = project.cwd
+        src = ppath.resolve(sourceCwd, path.slice(2) as PortablePath)
       } else {
-        if (parentLocator === null) {
-          throw new Error(`Protocol path ${path} requires a parent locator`)
-        }
+        if (parentLocator === null) continue
 
         const parentWorkspace = project.tryWorkspaceByLocator(parentLocator)
 
         if (!parentWorkspace) continue
+        if (parentWorkspace !== project.topLevelWorkspace && parentWorkspace !== workspace) continue
 
-        relativePath =
-          parentWorkspace === workspace ? path : ppath.join(parentWorkspace.relativeCwd, path)
-        src = ppath.join(parentWorkspace.cwd, path)
+        sourceCwd = parentWorkspace.cwd
+        src = ppath.resolve(sourceCwd, path)
       }
 
-      if (copiedPaths.has(relativePath)) continue
+      const relativePath = ppath.contains(sourceCwd, src)
 
-      copiedPaths.add(relativePath)
+      if (relativePath === null) {
+        throw new Error(`Patch path ${path} resolves outside the standalone workspace`)
+      }
+
+      const previousSrc = copiedPaths.get(relativePath)
+
+      if (previousSrc === src) continue
+
+      if (previousSrc) {
+        throw new Error(`Patch files ${previousSrc} and ${src} resolve to ${relativePath}`)
+      }
+
+      copiedPaths.set(relativePath, src)
 
       const dest = ppath.join(destination, relativePath)
 

--- a/yarn/pack-utils/src/export/exportUtils.ts
+++ b/yarn/pack-utils/src/export/exportUtils.ts
@@ -3,28 +3,30 @@
 
 // @ts-nocheck
 
-import { createGzip }            from 'node:zlib'
+import { createGzip }             from 'node:zlib'
 
-import { Project }               from '@yarnpkg/core'
-import { VirtualFetcher }        from '@yarnpkg/core'
-import { Workspace }             from '@yarnpkg/core'
-import { MultiFetcher }          from '@yarnpkg/core'
-import { CwdFS }                 from '@yarnpkg/fslib'
-import { Filename }              from '@yarnpkg/fslib'
-import { PortablePath }          from '@yarnpkg/fslib'
-import { ZipCompression }        from '@yarnpkg/fslib'
-import { structUtils }           from '@yarnpkg/core'
-import { tgzUtils }              from '@yarnpkg/core'
-import { ppath }                 from '@yarnpkg/fslib'
-import { xfs }                   from '@yarnpkg/fslib'
-import { packUtils }             from '@yarnpkg/plugin-pack'
-import tar                       from 'tar-stream'
+import { Project }                from '@yarnpkg/core'
+import { VirtualFetcher }         from '@yarnpkg/core'
+import { Workspace }              from '@yarnpkg/core'
+import { MultiFetcher }           from '@yarnpkg/core'
+import { CwdFS }                  from '@yarnpkg/fslib'
+import { Filename }               from '@yarnpkg/fslib'
+import { PortablePath }           from '@yarnpkg/fslib'
+import { ZipCompression }         from '@yarnpkg/fslib'
+import { structUtils }            from '@yarnpkg/core'
+import { tgzUtils }               from '@yarnpkg/core'
+import { ppath }                  from '@yarnpkg/fslib'
+import { xfs }                    from '@yarnpkg/fslib'
+import { packUtils }              from '@yarnpkg/plugin-pack'
+import tar                        from 'tar-stream'
 
-import { MultiResolver }         from './MultiResolver.js'
-import { ProtocolResolver }      from './ProtocolResolver.js'
-import { VirtualResolver }       from './VirtualResolver.js'
-import { WorkspacePackFetcher }  from './WorkspacePackFetcher.js'
-import { WorkspacePackResolver } from './WorkspacePackResolver.js'
+import { MultiResolver }          from './MultiResolver.js'
+import { ProtocolResolver }       from './ProtocolResolver.js'
+import { VirtualResolver }        from './VirtualResolver.js'
+import { WorkspacePackFetcher }   from './WorkspacePackFetcher.js'
+import { WorkspacePackResolver }  from './WorkspacePackResolver.js'
+import { getWorkspacePatchPaths } from '../patch-files/paths.js'
+import { resolvePatchPath }       from '../patch-files/paths.js'
 
 /**
  * Make a MultiFetcher that resolves workspaces using WorkspacePackFetcher
@@ -75,9 +77,23 @@ export const makeExportDir = async ({ locator, project }: Workspace) => {
   return exportDir
 }
 
+export const getWorkspacePackFiles = async (workspace: Workspace) => {
+  const files = new Set(await packUtils.genPackList(workspace))
+
+  for (const path of getWorkspacePatchPaths(workspace)) {
+    if (path.startsWith('~/')) continue
+
+    const { relativePath } = resolvePatchPath(workspace.cwd, path, 'packed workspace')
+
+    files.add(relativePath)
+  }
+
+  return Array.from(files).sort()
+}
+
 export const genPackTgz = async (workspace: Workspace) => {
   const packDir = await xfs.mktempPromise()
-  const pack = await packUtils.genPackStream(workspace)
+  const pack = await packUtils.genPackStream(workspace, await getWorkspacePackFiles(workspace))
   const target = ppath.join(packDir, `package.tgz` as Filename)
   const write = xfs.createWriteStream(target)
 
@@ -98,7 +114,7 @@ export const genPackZip = async (
   }
 ) => {
   return await xfs.mktempPromise(async (packDir) => {
-    const pack = await packUtils.genPackStream(workspace)
+    const pack = await packUtils.genPackStream(workspace, await getWorkspacePackFiles(workspace))
     const target = ppath.join(packDir, `package.tgz` as Filename)
     const write = xfs.createWriteStream(target)
 

--- a/yarn/pack-utils/src/pack.utils.test.ts
+++ b/yarn/pack-utils/src/pack.utils.test.ts
@@ -1,5 +1,6 @@
 import type { Project }                  from '@yarnpkg/core'
 import type { Report }                   from '@yarnpkg/core'
+import type { Workspace }                from '@yarnpkg/core'
 import type { PortablePath }             from '@yarnpkg/fslib'
 
 import assert                            from 'node:assert/strict'
@@ -143,6 +144,7 @@ test('should copy project-relative protocol files', async () => {
           cwd: source,
           storedDescriptors: new Map([[patchDescriptor.descriptorHash, patchDescriptor]]),
         } as unknown as Project,
+        {} as unknown as Workspace,
         destination,
         { reportInfo: () => undefined } as unknown as Report,
         (descriptor) => {
@@ -164,7 +166,50 @@ test('should copy project-relative protocol files', async () => {
   })
 })
 
-test('should preserve parent-workspace-relative protocol file copying', async () => {
+test('should copy packed-workspace-relative protocol files to the packed root', async () => {
+  await xfs.mktempPromise(async (source) => {
+    await xfs.mktempPromise(async (destination) => {
+      const parentRelativeCwd = 'packages/parent' as PortablePath
+      const parentCwd = ppath.join(source, parentRelativeCwd)
+      const protocolPath = 'protocol/example.txt' as PortablePath
+      const sourceProtocolPath = ppath.join(parentCwd, protocolPath)
+      const parentLocator = structUtils.makeLocator(
+        structUtils.makeIdent(null, 'parent'),
+        'workspace:packages/parent'
+      )
+
+      await mkdir(npath.dirname(npath.fromPortablePath(sourceProtocolPath)), { recursive: true })
+      await writeFile(npath.fromPortablePath(sourceProtocolPath), 'protocol content\n')
+
+      const workspace = { cwd: parentCwd, relativeCwd: parentRelativeCwd } as unknown as Workspace
+
+      await copyProtocolFiles(
+        {
+          cwd: source,
+          getWorkspaceByLocator: (locator: typeof parentLocator) => {
+            assert.equal(locator, parentLocator)
+
+            return workspace
+          },
+          storedDescriptors: new Map([
+            ['protocol', structUtils.makeDescriptor(parentLocator, 'protocol:example')],
+          ]),
+        } as unknown as Project,
+        workspace,
+        destination,
+        { reportInfo: () => undefined } as unknown as Report,
+        () => ({ parentLocator, paths: [protocolPath] })
+      )
+
+      assert.equal(
+        await xfs.readFilePromise(ppath.join(destination, protocolPath), 'utf8'),
+        'protocol content\n'
+      )
+    })
+  })
+})
+
+test('should preserve other-workspace-relative protocol file copying', async () => {
   await xfs.mktempPromise(async (source) => {
     await xfs.mktempPromise(async (destination) => {
       const parentRelativeCwd = 'packages/parent' as PortablePath
@@ -191,6 +236,7 @@ test('should preserve parent-workspace-relative protocol file copying', async ()
             ['protocol', structUtils.makeDescriptor(parentLocator, 'protocol:example')],
           ]),
         } as unknown as Project,
+        {} as unknown as Workspace,
         destination,
         { reportInfo: () => undefined } as unknown as Report,
         () => ({ parentLocator, paths: [protocolPath] })

--- a/yarn/pack-utils/src/pack.utils.test.ts
+++ b/yarn/pack-utils/src/pack.utils.test.ts
@@ -1,6 +1,5 @@
 import type { Project }                  from '@yarnpkg/core'
 import type { Report }                   from '@yarnpkg/core'
-import type { Descriptor }               from '@yarnpkg/core'
 import type { PortablePath }             from '@yarnpkg/fslib'
 
 import assert                            from 'node:assert/strict'
@@ -9,9 +8,11 @@ import { writeFile }                     from 'node:fs/promises'
 import { arch }                          from 'node:os'
 import test                              from 'node:test'
 
+import { structUtils }                   from '@yarnpkg/core'
 import { npath }                         from '@yarnpkg/fslib'
 import { ppath }                         from '@yarnpkg/fslib'
 import { xfs }                           from '@yarnpkg/fslib'
+import { patchUtils }                    from '@yarnpkg/plugin-patch'
 
 import { IMAGE_PACK_NODE_LINKER }        from './pack.utils.js'
 import { copyYarnRelease }               from './copy.utils.js'
@@ -124,6 +125,15 @@ test('should copy project-relative protocol files', async () => {
     await xfs.mktempPromise(async (destination) => {
       const patchPath = '.yarn/patches/example.patch'
       const sourcePatchPath = ppath.join(source, patchPath)
+      const sourceDescriptor = structUtils.makeDescriptor(
+        structUtils.makeIdent(null, 'example'),
+        'npm:1.0.0'
+      )
+      const patchDescriptor = patchUtils.makeDescriptor(sourceDescriptor, {
+        parentLocator: null,
+        patchPaths: [`optional!~/${patchPath}` as PortablePath],
+        sourceDescriptor,
+      })
 
       await mkdir(npath.dirname(npath.fromPortablePath(sourcePatchPath)), { recursive: true })
       await writeFile(npath.fromPortablePath(sourcePatchPath), 'patch content\n')
@@ -131,16 +141,64 @@ test('should copy project-relative protocol files', async () => {
       await copyProtocolFiles(
         {
           cwd: source,
-          storedDescriptors: new Map([['patch', { range: 'patch:example' } as Descriptor]]),
+          storedDescriptors: new Map([[patchDescriptor.descriptorHash, patchDescriptor]]),
         } as unknown as Project,
         destination,
         { reportInfo: () => undefined } as unknown as Report,
-        () => ({ parentLocator: null, paths: [`~/${patchPath}` as PortablePath] })
+        (descriptor) => {
+          if (!patchUtils.isPatchDescriptor(descriptor)) {
+            return undefined
+          }
+
+          const { parentLocator, patchPaths } = patchUtils.parseDescriptor(descriptor)
+
+          return { parentLocator, paths: patchPaths }
+        }
       )
 
       assert.equal(
         await xfs.readFilePromise(ppath.join(destination, patchPath), 'utf8'),
         'patch content\n'
+      )
+    })
+  })
+})
+
+test('should preserve parent-workspace-relative protocol file copying', async () => {
+  await xfs.mktempPromise(async (source) => {
+    await xfs.mktempPromise(async (destination) => {
+      const parentRelativeCwd = 'packages/parent' as PortablePath
+      const parentCwd = ppath.join(source, parentRelativeCwd)
+      const protocolPath = 'protocol/example.txt' as PortablePath
+      const sourceProtocolPath = ppath.join(parentCwd, protocolPath)
+      const parentLocator = structUtils.makeLocator(
+        structUtils.makeIdent(null, 'parent'),
+        'workspace:packages/parent'
+      )
+
+      await mkdir(npath.dirname(npath.fromPortablePath(sourceProtocolPath)), { recursive: true })
+      await writeFile(npath.fromPortablePath(sourceProtocolPath), 'protocol content\n')
+
+      await copyProtocolFiles(
+        {
+          cwd: source,
+          getWorkspaceByLocator: (locator: typeof parentLocator) => {
+            assert.equal(locator, parentLocator)
+
+            return { cwd: parentCwd, relativeCwd: parentRelativeCwd }
+          },
+          storedDescriptors: new Map([
+            ['protocol', structUtils.makeDescriptor(parentLocator, 'protocol:example')],
+          ]),
+        } as unknown as Project,
+        destination,
+        { reportInfo: () => undefined } as unknown as Report,
+        () => ({ parentLocator, paths: [protocolPath] })
+      )
+
+      assert.equal(
+        await xfs.readFilePromise(ppath.join(destination, parentRelativeCwd, protocolPath), 'utf8'),
+        'protocol content\n'
       )
     })
   })

--- a/yarn/pack-utils/src/pack.utils.test.ts
+++ b/yarn/pack-utils/src/pack.utils.test.ts
@@ -38,6 +38,31 @@ const makePatchDescriptor = (
   })
 }
 
+const makeResolution = (descriptor: ReturnType<typeof makePatchDescriptor>) => ({
+  pattern: {
+    descriptor: {
+      fullName: structUtils.stringifyIdent(descriptor),
+    },
+  },
+  reference: descriptor.range,
+})
+
+const makeWorkspace = (
+  cwd: PortablePath,
+  dependencies: Array<ReturnType<typeof makePatchDescriptor>> = [],
+  resolutions: Array<ReturnType<typeof makeResolution>> = []
+): Workspace =>
+  ({
+    cwd,
+    manifest: {
+      dependencies: new Map(
+        dependencies.map((descriptor) => [descriptor.identHash, descriptor] as const)
+      ),
+      peerDependencies: new Map(),
+      resolutions,
+    },
+  }) as unknown as Workspace
+
 test('should materialize image pack runtime with PnP linker', () => {
   assert.equal(IMAGE_PACK_NODE_LINKER, 'pnp')
 })
@@ -147,7 +172,8 @@ test('should copy project-relative patch files', async () => {
       const patchDescriptor = makePatchDescriptor('example', null, [
         `optional!~/${patchPath}` as PortablePath,
       ])
-      const workspace = {} as Workspace
+      const topLevelWorkspace = makeWorkspace(source, [], [makeResolution(patchDescriptor)])
+      const workspace = makeWorkspace(ppath.join(source, 'packages/app'))
 
       await mkdir(npath.dirname(npath.fromPortablePath(sourcePatchPath)), { recursive: true })
       await writeFile(npath.fromPortablePath(sourcePatchPath), 'patch content\n')
@@ -155,8 +181,7 @@ test('should copy project-relative patch files', async () => {
       await copyPatchFiles(
         {
           cwd: source,
-          topLevelWorkspace: workspace,
-          storedDescriptors: new Map([[patchDescriptor.descriptorHash, patchDescriptor]]),
+          topLevelWorkspace,
         } as unknown as Project,
         workspace,
         destination,
@@ -181,8 +206,8 @@ test('should copy top-level-workspace-relative patch files to the packed root', 
         'workspace:.'
       )
       const patchDescriptor = makePatchDescriptor('example', parentLocator, [patchPath])
-      const topLevelWorkspace = { cwd: source, relativeCwd: '.' as PortablePath } as Workspace
-      const workspace = { cwd: ppath.join(source, 'packages/app') } as Workspace
+      const topLevelWorkspace = makeWorkspace(source, [], [makeResolution(patchDescriptor)])
+      const workspace = makeWorkspace(ppath.join(source, 'packages/app'))
 
       await mkdir(npath.dirname(npath.fromPortablePath(sourcePatchPath)), { recursive: true })
       await writeFile(npath.fromPortablePath(sourcePatchPath), 'patch content\n')
@@ -191,12 +216,6 @@ test('should copy top-level-workspace-relative patch files to the packed root', 
         {
           cwd: source,
           topLevelWorkspace,
-          tryWorkspaceByLocator: (locator: typeof parentLocator) => {
-            assert.equal(locator.locatorHash, parentLocator.locatorHash)
-
-            return topLevelWorkspace
-          },
-          storedDescriptors: new Map([[patchDescriptor.descriptorHash, patchDescriptor]]),
         } as unknown as Project,
         workspace,
         destination,
@@ -222,8 +241,8 @@ test('should copy packed-workspace-relative patch files to the packed root', asy
         'workspace:packages/app'
       )
       const patchDescriptor = makePatchDescriptor('example', parentLocator, [patchPath])
-      const topLevelWorkspace = { cwd: source } as Workspace
-      const workspace = { cwd: workspaceCwd } as Workspace
+      const topLevelWorkspace = makeWorkspace(source)
+      const workspace = makeWorkspace(workspaceCwd, [patchDescriptor])
 
       await mkdir(npath.dirname(npath.fromPortablePath(sourcePatchPath)), { recursive: true })
       await writeFile(npath.fromPortablePath(sourcePatchPath), 'patch content\n')
@@ -232,12 +251,6 @@ test('should copy packed-workspace-relative patch files to the packed root', asy
         {
           cwd: source,
           topLevelWorkspace,
-          tryWorkspaceByLocator: (locator: typeof parentLocator) => {
-            assert.equal(locator.locatorHash, parentLocator.locatorHash)
-
-            return workspace
-          },
-          storedDescriptors: new Map([[patchDescriptor.descriptorHash, patchDescriptor]]),
         } as unknown as Project,
         workspace,
         destination,
@@ -262,15 +275,13 @@ test('should reject packed-workspace patch files outside the packed root', async
         'workspace:packages/app'
       )
       const patchDescriptor = makePatchDescriptor('example', parentLocator, [patchPath])
-      const workspace = { cwd: workspaceCwd } as Workspace
+      const workspace = makeWorkspace(workspaceCwd, [patchDescriptor])
 
       await assert.rejects(
         copyPatchFiles(
           {
             cwd: source,
-            topLevelWorkspace: { cwd: source },
-            tryWorkspaceByLocator: () => workspace,
-            storedDescriptors: new Map([[patchDescriptor.descriptorHash, patchDescriptor]]),
+            topLevelWorkspace: makeWorkspace(source),
           } as unknown as Project,
           workspace,
           destination,
@@ -304,7 +315,8 @@ test('should reject patch files collapsed onto the same packed path', async () =
       const workspacePatchDescriptor = makePatchDescriptor('workspace-example', parentLocator, [
         patchPath,
       ])
-      const workspace = { cwd: workspaceCwd } as Workspace
+      const topLevelWorkspace = makeWorkspace(source, [], [makeResolution(projectPatchDescriptor)])
+      const workspace = makeWorkspace(workspaceCwd, [workspacePatchDescriptor])
 
       await mkdir(npath.dirname(npath.fromPortablePath(projectPatchPath)), { recursive: true })
       await mkdir(npath.dirname(npath.fromPortablePath(workspacePatchPath)), { recursive: true })
@@ -315,12 +327,7 @@ test('should reject patch files collapsed onto the same packed path', async () =
         copyPatchFiles(
           {
             cwd: source,
-            topLevelWorkspace: { cwd: source },
-            tryWorkspaceByLocator: () => workspace,
-            storedDescriptors: new Map([
-              [projectPatchDescriptor.descriptorHash, projectPatchDescriptor],
-              [workspacePatchDescriptor.descriptorHash, workspacePatchDescriptor],
-            ]),
+            topLevelWorkspace,
           } as unknown as Project,
           workspace,
           destination,
@@ -332,7 +339,7 @@ test('should reject patch files collapsed onto the same packed path', async () =
   })
 })
 
-test('should skip patch files owned by non-workspace packages', async () => {
+test('should ignore patch descriptors outside the packed manifest', async () => {
   await xfs.mktempPromise(async (destination) => {
     const parentLocator = structUtils.makeLocator(
       structUtils.makeIdent(null, 'parent'),
@@ -343,18 +350,13 @@ test('should skip patch files owned by non-workspace packages', async () => {
 
     await copyPatchFiles(
       {
-        topLevelWorkspace: {},
-        tryWorkspaceByLocator: (locator: typeof parentLocator) => {
-          assert.equal(locator.locatorHash, parentLocator.locatorHash)
-
-          return null
-        },
+        topLevelWorkspace: makeWorkspace(destination),
         storedDescriptors: new Map([[patchDescriptor.descriptorHash, patchDescriptor]]),
       } as unknown as Project,
-      {} as Workspace,
+      makeWorkspace(destination),
       destination,
       {
-        reportInfo: () => assert.fail('non-workspace patch file should not be copied'),
+        reportInfo: () => assert.fail('unrelated patch file should not be copied'),
       } as unknown as Report
     )
   })

--- a/yarn/pack-utils/src/pack.utils.test.ts
+++ b/yarn/pack-utils/src/pack.utils.test.ts
@@ -1,6 +1,7 @@
 import type { Project }                  from '@yarnpkg/core'
 import type { Report }                   from '@yarnpkg/core'
 import type { Workspace }                from '@yarnpkg/core'
+import type { Locator }                  from '@yarnpkg/core'
 import type { PortablePath }             from '@yarnpkg/fslib'
 
 import assert                            from 'node:assert/strict'
@@ -17,8 +18,25 @@ import { patchUtils }                    from '@yarnpkg/plugin-patch'
 
 import { IMAGE_PACK_NODE_LINKER }        from './pack.utils.js'
 import { copyYarnRelease }               from './copy.utils.js'
-import { copyProtocolFiles }             from './copy.utils.js'
+import { copyPatchFiles }                from './copy.utils.js'
 import { resolveSupportedArchitectures } from './pack.utils.js'
+
+const makePatchDescriptor = (
+  name: string,
+  parentLocator: Locator | null,
+  patchPaths: Array<PortablePath>
+) => {
+  const sourceDescriptor = structUtils.makeDescriptor(
+    structUtils.makeIdent(null, name),
+    'npm:1.0.0'
+  )
+
+  return patchUtils.makeDescriptor(sourceDescriptor, {
+    parentLocator,
+    patchPaths,
+    sourceDescriptor,
+  })
+}
 
 test('should materialize image pack runtime with PnP linker', () => {
   assert.equal(IMAGE_PACK_NODE_LINKER, 'pnp')
@@ -121,41 +139,28 @@ test('should copy yarn release from native yarn path', async (context) => {
   })
 })
 
-test('should copy project-relative protocol files', async () => {
+test('should copy project-relative patch files', async () => {
   await xfs.mktempPromise(async (source) => {
     await xfs.mktempPromise(async (destination) => {
       const patchPath = '.yarn/patches/example.patch'
       const sourcePatchPath = ppath.join(source, patchPath)
-      const sourceDescriptor = structUtils.makeDescriptor(
-        structUtils.makeIdent(null, 'example'),
-        'npm:1.0.0'
-      )
-      const patchDescriptor = patchUtils.makeDescriptor(sourceDescriptor, {
-        parentLocator: null,
-        patchPaths: [`optional!~/${patchPath}` as PortablePath],
-        sourceDescriptor,
-      })
+      const patchDescriptor = makePatchDescriptor('example', null, [
+        `optional!~/${patchPath}` as PortablePath,
+      ])
+      const workspace = {} as Workspace
 
       await mkdir(npath.dirname(npath.fromPortablePath(sourcePatchPath)), { recursive: true })
       await writeFile(npath.fromPortablePath(sourcePatchPath), 'patch content\n')
 
-      await copyProtocolFiles(
+      await copyPatchFiles(
         {
           cwd: source,
+          topLevelWorkspace: workspace,
           storedDescriptors: new Map([[patchDescriptor.descriptorHash, patchDescriptor]]),
         } as unknown as Project,
-        {} as unknown as Workspace,
+        workspace,
         destination,
-        { reportInfo: () => undefined } as unknown as Report,
-        (descriptor) => {
-          if (!patchUtils.isPatchDescriptor(descriptor)) {
-            return undefined
-          }
-
-          const { parentLocator, patchPaths } = patchUtils.parseDescriptor(descriptor)
-
-          return { parentLocator, paths: patchPaths }
-        }
+        { reportInfo: () => undefined } as unknown as Report
       )
 
       assert.equal(
@@ -166,115 +171,191 @@ test('should copy project-relative protocol files', async () => {
   })
 })
 
-test('should copy packed-workspace-relative protocol files to the packed root', async () => {
+test('should copy top-level-workspace-relative patch files to the packed root', async () => {
   await xfs.mktempPromise(async (source) => {
     await xfs.mktempPromise(async (destination) => {
-      const parentRelativeCwd = 'packages/parent' as PortablePath
-      const parentCwd = ppath.join(source, parentRelativeCwd)
-      const protocolPath = 'protocol/example.txt' as PortablePath
-      const sourceProtocolPath = ppath.join(parentCwd, protocolPath)
+      const patchPath = '.yarn/patches/example.patch' as PortablePath
+      const sourcePatchPath = ppath.join(source, patchPath)
       const parentLocator = structUtils.makeLocator(
-        structUtils.makeIdent(null, 'parent'),
-        'workspace:packages/parent'
+        structUtils.makeIdent(null, 'root'),
+        'workspace:.'
       )
+      const patchDescriptor = makePatchDescriptor('example', parentLocator, [patchPath])
+      const topLevelWorkspace = { cwd: source, relativeCwd: '.' as PortablePath } as Workspace
+      const workspace = { cwd: ppath.join(source, 'packages/app') } as Workspace
 
-      await mkdir(npath.dirname(npath.fromPortablePath(sourceProtocolPath)), { recursive: true })
-      await writeFile(npath.fromPortablePath(sourceProtocolPath), 'protocol content\n')
+      await mkdir(npath.dirname(npath.fromPortablePath(sourcePatchPath)), { recursive: true })
+      await writeFile(npath.fromPortablePath(sourcePatchPath), 'patch content\n')
 
-      const workspace = { cwd: parentCwd, relativeCwd: parentRelativeCwd } as unknown as Workspace
-
-      await copyProtocolFiles(
+      await copyPatchFiles(
         {
           cwd: source,
+          topLevelWorkspace,
           tryWorkspaceByLocator: (locator: typeof parentLocator) => {
-            assert.equal(locator, parentLocator)
+            assert.equal(locator.locatorHash, parentLocator.locatorHash)
 
-            return workspace
+            return topLevelWorkspace
           },
-          storedDescriptors: new Map([
-            ['protocol', structUtils.makeDescriptor(parentLocator, 'protocol:example')],
-          ]),
+          storedDescriptors: new Map([[patchDescriptor.descriptorHash, patchDescriptor]]),
         } as unknown as Project,
         workspace,
         destination,
-        { reportInfo: () => undefined } as unknown as Report,
-        () => ({ parentLocator, paths: [protocolPath] })
+        { reportInfo: () => undefined } as unknown as Report
       )
 
       assert.equal(
-        await xfs.readFilePromise(ppath.join(destination, protocolPath), 'utf8'),
-        'protocol content\n'
+        await xfs.readFilePromise(ppath.join(destination, patchPath), 'utf8'),
+        'patch content\n'
       )
     })
   })
 })
 
-test('should preserve other-workspace-relative protocol file copying', async () => {
+test('should copy packed-workspace-relative patch files to the packed root', async () => {
   await xfs.mktempPromise(async (source) => {
     await xfs.mktempPromise(async (destination) => {
-      const parentRelativeCwd = 'packages/parent' as PortablePath
-      const parentCwd = ppath.join(source, parentRelativeCwd)
-      const protocolPath = 'protocol/example.txt' as PortablePath
-      const sourceProtocolPath = ppath.join(parentCwd, protocolPath)
+      const workspaceCwd = ppath.join(source, 'packages/app')
+      const patchPath = 'patches/example.patch' as PortablePath
+      const sourcePatchPath = ppath.join(workspaceCwd, patchPath)
       const parentLocator = structUtils.makeLocator(
-        structUtils.makeIdent(null, 'parent'),
-        'workspace:packages/parent'
+        structUtils.makeIdent(null, 'app'),
+        'workspace:packages/app'
       )
+      const patchDescriptor = makePatchDescriptor('example', parentLocator, [patchPath])
+      const topLevelWorkspace = { cwd: source } as Workspace
+      const workspace = { cwd: workspaceCwd } as Workspace
 
-      await mkdir(npath.dirname(npath.fromPortablePath(sourceProtocolPath)), { recursive: true })
-      await writeFile(npath.fromPortablePath(sourceProtocolPath), 'protocol content\n')
+      await mkdir(npath.dirname(npath.fromPortablePath(sourcePatchPath)), { recursive: true })
+      await writeFile(npath.fromPortablePath(sourcePatchPath), 'patch content\n')
 
-      await copyProtocolFiles(
+      await copyPatchFiles(
         {
           cwd: source,
+          topLevelWorkspace,
           tryWorkspaceByLocator: (locator: typeof parentLocator) => {
-            assert.equal(locator, parentLocator)
+            assert.equal(locator.locatorHash, parentLocator.locatorHash)
 
-            return { cwd: parentCwd, relativeCwd: parentRelativeCwd }
+            return workspace
           },
-          storedDescriptors: new Map([
-            ['protocol', structUtils.makeDescriptor(parentLocator, 'protocol:example')],
-          ]),
+          storedDescriptors: new Map([[patchDescriptor.descriptorHash, patchDescriptor]]),
         } as unknown as Project,
-        {} as unknown as Workspace,
+        workspace,
         destination,
-        { reportInfo: () => undefined } as unknown as Report,
-        () => ({ parentLocator, paths: [protocolPath] })
+        { reportInfo: () => undefined } as unknown as Report
       )
 
       assert.equal(
-        await xfs.readFilePromise(ppath.join(destination, parentRelativeCwd, protocolPath), 'utf8'),
-        'protocol content\n'
+        await xfs.readFilePromise(ppath.join(destination, patchPath), 'utf8'),
+        'patch content\n'
       )
     })
   })
 })
 
-test('should skip relative protocol files owned by non-workspace packages', async () => {
+test('should reject packed-workspace patch files outside the packed root', async () => {
+  await xfs.mktempPromise(async (source) => {
+    await xfs.mktempPromise(async (destination) => {
+      const workspaceCwd = ppath.join(source, 'packages/app')
+      const patchPath = '../patches/example.patch' as PortablePath
+      const parentLocator = structUtils.makeLocator(
+        structUtils.makeIdent(null, 'app'),
+        'workspace:packages/app'
+      )
+      const patchDescriptor = makePatchDescriptor('example', parentLocator, [patchPath])
+      const workspace = { cwd: workspaceCwd } as Workspace
+
+      await assert.rejects(
+        copyPatchFiles(
+          {
+            cwd: source,
+            topLevelWorkspace: { cwd: source },
+            tryWorkspaceByLocator: () => workspace,
+            storedDescriptors: new Map([[patchDescriptor.descriptorHash, patchDescriptor]]),
+          } as unknown as Project,
+          workspace,
+          destination,
+          { reportInfo: () => undefined } as unknown as Report
+        ),
+        /resolves outside the standalone workspace/
+      )
+
+      assert.equal(
+        await xfs.existsPromise(ppath.join(ppath.dirname(destination), 'patches/example.patch')),
+        false
+      )
+    })
+  })
+})
+
+test('should reject patch files collapsed onto the same packed path', async () => {
+  await xfs.mktempPromise(async (source) => {
+    await xfs.mktempPromise(async (destination) => {
+      const patchPath = 'patches/example.patch' as PortablePath
+      const workspaceCwd = ppath.join(source, 'packages/app')
+      const projectPatchPath = ppath.join(source, patchPath)
+      const workspacePatchPath = ppath.join(workspaceCwd, patchPath)
+      const parentLocator = structUtils.makeLocator(
+        structUtils.makeIdent(null, 'app'),
+        'workspace:packages/app'
+      )
+      const projectPatchDescriptor = makePatchDescriptor('project-example', null, [
+        `~/${patchPath}` as PortablePath,
+      ])
+      const workspacePatchDescriptor = makePatchDescriptor('workspace-example', parentLocator, [
+        patchPath,
+      ])
+      const workspace = { cwd: workspaceCwd } as Workspace
+
+      await mkdir(npath.dirname(npath.fromPortablePath(projectPatchPath)), { recursive: true })
+      await mkdir(npath.dirname(npath.fromPortablePath(workspacePatchPath)), { recursive: true })
+      await writeFile(npath.fromPortablePath(projectPatchPath), 'project patch\n')
+      await writeFile(npath.fromPortablePath(workspacePatchPath), 'workspace patch\n')
+
+      await assert.rejects(
+        copyPatchFiles(
+          {
+            cwd: source,
+            topLevelWorkspace: { cwd: source },
+            tryWorkspaceByLocator: () => workspace,
+            storedDescriptors: new Map([
+              [projectPatchDescriptor.descriptorHash, projectPatchDescriptor],
+              [workspacePatchDescriptor.descriptorHash, workspacePatchDescriptor],
+            ]),
+          } as unknown as Project,
+          workspace,
+          destination,
+          { reportInfo: () => undefined } as unknown as Report
+        ),
+        /resolve to patches\/example\.patch/
+      )
+    })
+  })
+})
+
+test('should skip patch files owned by non-workspace packages', async () => {
   await xfs.mktempPromise(async (destination) => {
     const parentLocator = structUtils.makeLocator(
       structUtils.makeIdent(null, 'parent'),
       'npm:1.0.0'
     )
-    const protocolPath = 'protocol/example.txt' as PortablePath
+    const patchPath = 'patches/example.patch' as PortablePath
+    const patchDescriptor = makePatchDescriptor('example', parentLocator, [patchPath])
 
-    await copyProtocolFiles(
+    await copyPatchFiles(
       {
+        topLevelWorkspace: {},
         tryWorkspaceByLocator: (locator: typeof parentLocator) => {
-          assert.equal(locator, parentLocator)
+          assert.equal(locator.locatorHash, parentLocator.locatorHash)
 
           return null
         },
-        storedDescriptors: new Map([
-          ['protocol', structUtils.makeDescriptor(parentLocator, 'protocol:example')],
-        ]),
+        storedDescriptors: new Map([[patchDescriptor.descriptorHash, patchDescriptor]]),
       } as unknown as Project,
-      {} as unknown as Workspace,
+      {} as Workspace,
       destination,
       {
-        reportInfo: () => assert.fail('non-workspace protocol file should not be copied'),
-      } as unknown as Report,
-      () => ({ parentLocator, paths: [protocolPath] })
+        reportInfo: () => assert.fail('non-workspace patch file should not be copied'),
+      } as unknown as Report
     )
   })
 })

--- a/yarn/pack-utils/src/pack.utils.test.ts
+++ b/yarn/pack-utils/src/pack.utils.test.ts
@@ -1,5 +1,7 @@
 import type { Project }                  from '@yarnpkg/core'
 import type { Report }                   from '@yarnpkg/core'
+import type { Descriptor }               from '@yarnpkg/core'
+import type { PortablePath }             from '@yarnpkg/fslib'
 
 import assert                            from 'node:assert/strict'
 import { mkdir }                         from 'node:fs/promises'
@@ -13,6 +15,7 @@ import { xfs }                           from '@yarnpkg/fslib'
 
 import { IMAGE_PACK_NODE_LINKER }        from './pack.utils.js'
 import { copyYarnRelease }               from './copy.utils.js'
+import { copyProtocolFiles }             from './copy.utils.js'
 import { resolveSupportedArchitectures } from './pack.utils.js'
 
 test('should materialize image pack runtime with PnP linker', () => {
@@ -111,6 +114,33 @@ test('should copy yarn release from native yarn path', async (context) => {
       assert.equal(
         await xfs.existsPromise(ppath.join(destination, '.yarn/releases/yarn.mjs')),
         true
+      )
+    })
+  })
+})
+
+test('should copy project-relative protocol files', async () => {
+  await xfs.mktempPromise(async (source) => {
+    await xfs.mktempPromise(async (destination) => {
+      const patchPath = '.yarn/patches/example.patch'
+      const sourcePatchPath = ppath.join(source, patchPath)
+
+      await mkdir(npath.dirname(npath.fromPortablePath(sourcePatchPath)), { recursive: true })
+      await writeFile(npath.fromPortablePath(sourcePatchPath), 'patch content\n')
+
+      await copyProtocolFiles(
+        {
+          cwd: source,
+          storedDescriptors: new Map([['patch', { range: 'patch:example' } as Descriptor]]),
+        } as unknown as Project,
+        destination,
+        { reportInfo: () => undefined } as unknown as Report,
+        () => ({ parentLocator: null, paths: [`~/${patchPath}` as PortablePath] })
+      )
+
+      assert.equal(
+        await xfs.readFilePromise(ppath.join(destination, patchPath), 'utf8'),
+        'patch content\n'
       )
     })
   })

--- a/yarn/pack-utils/src/pack.utils.test.ts
+++ b/yarn/pack-utils/src/pack.utils.test.ts
@@ -2,6 +2,7 @@ import type { Project }                  from '@yarnpkg/core'
 import type { Report }                   from '@yarnpkg/core'
 import type { Workspace }                from '@yarnpkg/core'
 import type { Locator }                  from '@yarnpkg/core'
+import type { Descriptor }               from '@yarnpkg/core'
 import type { PortablePath }             from '@yarnpkg/fslib'
 
 import assert                            from 'node:assert/strict'
@@ -14,11 +15,13 @@ import { structUtils }                   from '@yarnpkg/core'
 import { npath }                         from '@yarnpkg/fslib'
 import { ppath }                         from '@yarnpkg/fslib'
 import { xfs }                           from '@yarnpkg/fslib'
+import { packUtils }                     from '@yarnpkg/plugin-pack'
 import { patchUtils }                    from '@yarnpkg/plugin-patch'
 
 import { IMAGE_PACK_NODE_LINKER }        from './pack.utils.js'
 import { copyYarnRelease }               from './copy.utils.js'
 import { copyPatchFiles }                from './copy.utils.js'
+import { getWorkspacePackFiles }         from './export/exportUtils.js'
 import { resolveSupportedArchitectures } from './pack.utils.js'
 
 const makePatchDescriptor = (
@@ -49,19 +52,36 @@ const makeResolution = (descriptor: ReturnType<typeof makePatchDescriptor>) => (
 
 const makeWorkspace = (
   cwd: PortablePath,
-  dependencies: Array<ReturnType<typeof makePatchDescriptor>> = [],
+  dependencies: Array<Descriptor> = [],
   resolutions: Array<ReturnType<typeof makeResolution>> = []
-): Workspace =>
-  ({
+): Workspace => {
+  const dependencyMap = new Map(
+    dependencies.map((descriptor) => [descriptor.identHash, descriptor] as const)
+  )
+  const peerDependencyMap = new Map()
+
+  return {
     cwd,
     manifest: {
-      dependencies: new Map(
-        dependencies.map((descriptor) => [descriptor.identHash, descriptor] as const)
-      ),
-      peerDependencies: new Map(),
+      dependencies: dependencyMap,
+      getForScope: (scope: string) =>
+        scope === 'peerDependencies' ? peerDependencyMap : dependencyMap,
+      peerDependencies: peerDependencyMap,
       resolutions,
     },
-  }) as unknown as Workspace
+  } as unknown as Workspace
+}
+
+const makeProject = (
+  cwd: PortablePath,
+  topLevelWorkspace: Workspace,
+  tryWorkspaceByDescriptor: (descriptor: Descriptor) => Workspace | null = () => null
+): Project =>
+  ({
+    cwd,
+    topLevelWorkspace,
+    tryWorkspaceByDescriptor,
+  }) as unknown as Project
 
 test('should materialize image pack runtime with PnP linker', () => {
   assert.equal(IMAGE_PACK_NODE_LINKER, 'pnp')
@@ -178,15 +198,9 @@ test('should copy project-relative patch files', async () => {
       await mkdir(npath.dirname(npath.fromPortablePath(sourcePatchPath)), { recursive: true })
       await writeFile(npath.fromPortablePath(sourcePatchPath), 'patch content\n')
 
-      await copyPatchFiles(
-        {
-          cwd: source,
-          topLevelWorkspace,
-        } as unknown as Project,
-        workspace,
-        destination,
-        { reportInfo: () => undefined } as unknown as Report
-      )
+      await copyPatchFiles(makeProject(source, topLevelWorkspace), workspace, destination, {
+        reportInfo: () => undefined,
+      } as unknown as Report)
 
       assert.equal(
         await xfs.readFilePromise(ppath.join(destination, patchPath), 'utf8'),
@@ -212,15 +226,9 @@ test('should copy top-level-workspace-relative patch files to the packed root', 
       await mkdir(npath.dirname(npath.fromPortablePath(sourcePatchPath)), { recursive: true })
       await writeFile(npath.fromPortablePath(sourcePatchPath), 'patch content\n')
 
-      await copyPatchFiles(
-        {
-          cwd: source,
-          topLevelWorkspace,
-        } as unknown as Project,
-        workspace,
-        destination,
-        { reportInfo: () => undefined } as unknown as Report
-      )
+      await copyPatchFiles(makeProject(source, topLevelWorkspace), workspace, destination, {
+        reportInfo: () => undefined,
+      } as unknown as Report)
 
       assert.equal(
         await xfs.readFilePromise(ppath.join(destination, patchPath), 'utf8'),
@@ -230,75 +238,41 @@ test('should copy top-level-workspace-relative patch files to the packed root', 
   })
 })
 
-test('should copy packed-workspace-relative patch files to the packed root', async () => {
+test('should include workspace-relative patch files in the workspace pack', async (context) => {
   await xfs.mktempPromise(async (source) => {
-    await xfs.mktempPromise(async (destination) => {
-      const workspaceCwd = ppath.join(source, 'packages/app')
-      const patchPath = 'patches/example.patch' as PortablePath
-      const sourcePatchPath = ppath.join(workspaceCwd, patchPath)
-      const parentLocator = structUtils.makeLocator(
-        structUtils.makeIdent(null, 'app'),
-        'workspace:packages/app'
-      )
-      const patchDescriptor = makePatchDescriptor('example', parentLocator, [patchPath])
-      const topLevelWorkspace = makeWorkspace(source)
-      const workspace = makeWorkspace(workspaceCwd, [patchDescriptor])
+    const workspaceCwd = ppath.join(source, 'packages/app')
+    const patchPath = 'patches/example.patch' as PortablePath
+    const parentLocator = structUtils.makeLocator(
+      structUtils.makeIdent(null, 'app'),
+      'workspace:packages/app'
+    )
+    const patchDescriptor = makePatchDescriptor('example', parentLocator, [patchPath])
+    const workspace = makeWorkspace(workspaceCwd, [patchDescriptor])
 
-      await mkdir(npath.dirname(npath.fromPortablePath(sourcePatchPath)), { recursive: true })
-      await writeFile(npath.fromPortablePath(sourcePatchPath), 'patch content\n')
+    context.mock.method(packUtils, 'genPackList', async () => ['package.json' as PortablePath])
 
-      await copyPatchFiles(
-        {
-          cwd: source,
-          topLevelWorkspace,
-        } as unknown as Project,
-        workspace,
-        destination,
-        { reportInfo: () => undefined } as unknown as Report
-      )
-
-      assert.equal(
-        await xfs.readFilePromise(ppath.join(destination, patchPath), 'utf8'),
-        'patch content\n'
-      )
-    })
+    assert.deepEqual(await getWorkspacePackFiles(workspace), ['package.json', patchPath])
   })
 })
 
-test('should reject packed-workspace patch files outside the packed root', async () => {
+test('should reject workspace patch files outside the workspace pack', async (context) => {
   await xfs.mktempPromise(async (source) => {
-    await xfs.mktempPromise(async (destination) => {
-      const workspaceCwd = ppath.join(source, 'packages/app')
-      const patchPath = '../patches/example.patch' as PortablePath
-      const parentLocator = structUtils.makeLocator(
-        structUtils.makeIdent(null, 'app'),
-        'workspace:packages/app'
-      )
-      const patchDescriptor = makePatchDescriptor('example', parentLocator, [patchPath])
-      const workspace = makeWorkspace(workspaceCwd, [patchDescriptor])
+    const workspaceCwd = ppath.join(source, 'packages/app')
+    const patchPath = '../patches/example.patch' as PortablePath
+    const parentLocator = structUtils.makeLocator(
+      structUtils.makeIdent(null, 'app'),
+      'workspace:packages/app'
+    )
+    const patchDescriptor = makePatchDescriptor('example', parentLocator, [patchPath])
+    const workspace = makeWorkspace(workspaceCwd, [patchDescriptor])
 
-      await assert.rejects(
-        copyPatchFiles(
-          {
-            cwd: source,
-            topLevelWorkspace: makeWorkspace(source),
-          } as unknown as Project,
-          workspace,
-          destination,
-          { reportInfo: () => undefined } as unknown as Report
-        ),
-        /resolves outside the standalone workspace/
-      )
+    context.mock.method(packUtils, 'genPackList', async () => ['package.json' as PortablePath])
 
-      assert.equal(
-        await xfs.existsPromise(ppath.join(ppath.dirname(destination), 'patches/example.patch')),
-        false
-      )
-    })
+    await assert.rejects(getWorkspacePackFiles(workspace), /resolves outside the packed workspace/)
   })
 })
 
-test('should reject patch files collapsed onto the same packed path', async () => {
+test('should keep project and workspace patch paths in separate artifacts', async (context) => {
   await xfs.mktempPromise(async (source) => {
     await xfs.mktempPromise(async (destination) => {
       const patchPath = 'patches/example.patch' as PortablePath
@@ -323,18 +297,17 @@ test('should reject patch files collapsed onto the same packed path', async () =
       await writeFile(npath.fromPortablePath(projectPatchPath), 'project patch\n')
       await writeFile(npath.fromPortablePath(workspacePatchPath), 'workspace patch\n')
 
-      await assert.rejects(
-        copyPatchFiles(
-          {
-            cwd: source,
-            topLevelWorkspace,
-          } as unknown as Project,
-          workspace,
-          destination,
-          { reportInfo: () => undefined } as unknown as Report
-        ),
-        /resolve to patches\/example\.patch/
+      context.mock.method(packUtils, 'genPackList', async () => ['package.json' as PortablePath])
+
+      await copyPatchFiles(makeProject(source, topLevelWorkspace), workspace, destination, {
+        reportInfo: () => undefined,
+      } as unknown as Report)
+
+      assert.equal(
+        await xfs.readFilePromise(ppath.join(destination, patchPath), 'utf8'),
+        'project patch\n'
       )
+      assert.deepEqual(await getWorkspacePackFiles(workspace), ['package.json', patchPath])
     })
   })
 })
@@ -347,17 +320,49 @@ test('should ignore patch descriptors outside the packed manifest', async () => 
     )
     const patchPath = 'patches/example.patch' as PortablePath
     const patchDescriptor = makePatchDescriptor('example', parentLocator, [patchPath])
+    const topLevelWorkspace = makeWorkspace(destination)
 
     await copyPatchFiles(
-      {
-        topLevelWorkspace: makeWorkspace(destination),
+      Object.assign(makeProject(destination, topLevelWorkspace), {
         storedDescriptors: new Map([[patchDescriptor.descriptorHash, patchDescriptor]]),
-      } as unknown as Project,
+      }),
       makeWorkspace(destination),
       destination,
       {
         reportInfo: () => assert.fail('unrelated patch file should not be copied'),
       } as unknown as Report
     )
+  })
+})
+
+test('should copy project-relative patches from required workspaces', async () => {
+  await xfs.mktempPromise(async (source) => {
+    await xfs.mktempPromise(async (destination) => {
+      const patchPath = '.yarn/patches/example.patch' as PortablePath
+      const sourcePatchPath = ppath.join(source, patchPath)
+      const childIdent = structUtils.makeIdent(null, 'child')
+      const childDescriptor = structUtils.makeDescriptor(childIdent, 'workspace:*')
+      const childLocator = structUtils.makeLocator(childIdent, 'workspace:packages/child')
+      const patchDescriptor = makePatchDescriptor('example', childLocator, [
+        `~/${patchPath}` as PortablePath,
+      ])
+      const topLevelWorkspace = makeWorkspace(source)
+      const workspace = makeWorkspace(ppath.join(source, 'packages/app'), [childDescriptor])
+      const childWorkspace = makeWorkspace(ppath.join(source, 'packages/child'), [patchDescriptor])
+      const project = makeProject(source, topLevelWorkspace, (descriptor) =>
+        descriptor.identHash === childDescriptor.identHash ? childWorkspace : null)
+
+      await mkdir(npath.dirname(npath.fromPortablePath(sourcePatchPath)), { recursive: true })
+      await writeFile(npath.fromPortablePath(sourcePatchPath), 'patch content\n')
+
+      await copyPatchFiles(project, workspace, destination, {
+        reportInfo: () => undefined,
+      } as unknown as Report)
+
+      assert.equal(
+        await xfs.readFilePromise(ppath.join(destination, patchPath), 'utf8'),
+        'patch content\n'
+      )
+    })
   })
 })

--- a/yarn/pack-utils/src/pack.utils.test.ts
+++ b/yarn/pack-utils/src/pack.utils.test.ts
@@ -186,7 +186,7 @@ test('should copy packed-workspace-relative protocol files to the packed root', 
       await copyProtocolFiles(
         {
           cwd: source,
-          getWorkspaceByLocator: (locator: typeof parentLocator) => {
+          tryWorkspaceByLocator: (locator: typeof parentLocator) => {
             assert.equal(locator, parentLocator)
 
             return workspace
@@ -227,7 +227,7 @@ test('should preserve other-workspace-relative protocol file copying', async () 
       await copyProtocolFiles(
         {
           cwd: source,
-          getWorkspaceByLocator: (locator: typeof parentLocator) => {
+          tryWorkspaceByLocator: (locator: typeof parentLocator) => {
             assert.equal(locator, parentLocator)
 
             return { cwd: parentCwd, relativeCwd: parentRelativeCwd }
@@ -247,5 +247,34 @@ test('should preserve other-workspace-relative protocol file copying', async () 
         'protocol content\n'
       )
     })
+  })
+})
+
+test('should skip relative protocol files owned by non-workspace packages', async () => {
+  await xfs.mktempPromise(async (destination) => {
+    const parentLocator = structUtils.makeLocator(
+      structUtils.makeIdent(null, 'parent'),
+      'npm:1.0.0'
+    )
+    const protocolPath = 'protocol/example.txt' as PortablePath
+
+    await copyProtocolFiles(
+      {
+        tryWorkspaceByLocator: (locator: typeof parentLocator) => {
+          assert.equal(locator, parentLocator)
+
+          return null
+        },
+        storedDescriptors: new Map([
+          ['protocol', structUtils.makeDescriptor(parentLocator, 'protocol:example')],
+        ]),
+      } as unknown as Project,
+      {} as unknown as Workspace,
+      destination,
+      {
+        reportInfo: () => assert.fail('non-workspace protocol file should not be copied'),
+      } as unknown as Report,
+      () => ({ parentLocator, paths: [protocolPath] })
+    )
   })
 })

--- a/yarn/pack-utils/src/pack.utils.ts
+++ b/yarn/pack-utils/src/pack.utils.ts
@@ -13,11 +13,10 @@ import { CwdFS }                      from '@yarnpkg/fslib'
 import { tgzUtils }                   from '@yarnpkg/core'
 import { ppath }                      from '@yarnpkg/fslib'
 import { packUtils }                  from '@yarnpkg/plugin-pack'
-import { patchUtils }                 from '@yarnpkg/plugin-patch'
 
 import { ExportCache }                from './export/ExportCache.js'
 import { copyRcFile }                 from './copy.utils.js'
-import { copyProtocolFiles }          from './copy.utils.js'
+import { copyPatchFiles }             from './copy.utils.js'
 import { copyYarnRelease }            from './copy.utils.js'
 import { genPackTgz }                 from './export/exportUtils.js'
 import { makeFetcher }                from './export/exportUtils.js'
@@ -88,15 +87,7 @@ export const pack = async (
 
     await tgzUtils.extractArchiveTo(tgz, baseFs, { stripComponents: 1 })
     await copyRcFile(project, destination, report)
-    await copyProtocolFiles(project, workspace, destination, report, (descriptor) => {
-      if (!patchUtils.isPatchDescriptor(descriptor)) {
-        return undefined
-      }
-
-      const { parentLocator, patchPaths } = patchUtils.parseDescriptor(descriptor)
-
-      return { parentLocator, paths: patchPaths }
-    })
+    await copyPatchFiles(project, workspace, destination, report)
 
     if (project.configuration.get('yarnPath')) {
       await copyYarnRelease(project, destination, report)

--- a/yarn/pack-utils/src/pack.utils.ts
+++ b/yarn/pack-utils/src/pack.utils.ts
@@ -88,7 +88,7 @@ export const pack = async (
 
     await tgzUtils.extractArchiveTo(tgz, baseFs, { stripComponents: 1 })
     await copyRcFile(project, destination, report)
-    await copyProtocolFiles(project, destination, report, (descriptor) => {
+    await copyProtocolFiles(project, workspace, destination, report, (descriptor) => {
       if (!patchUtils.isPatchDescriptor(descriptor)) {
         return undefined
       }

--- a/yarn/pack-utils/src/pack.utils.ts
+++ b/yarn/pack-utils/src/pack.utils.ts
@@ -13,9 +13,11 @@ import { CwdFS }                      from '@yarnpkg/fslib'
 import { tgzUtils }                   from '@yarnpkg/core'
 import { ppath }                      from '@yarnpkg/fslib'
 import { packUtils }                  from '@yarnpkg/plugin-pack'
+import { patchUtils }                 from '@yarnpkg/plugin-patch'
 
 import { ExportCache }                from './export/ExportCache.js'
 import { copyRcFile }                 from './copy.utils.js'
+import { copyProtocolFiles }          from './copy.utils.js'
 import { copyYarnRelease }            from './copy.utils.js'
 import { genPackTgz }                 from './export/exportUtils.js'
 import { makeFetcher }                from './export/exportUtils.js'
@@ -86,6 +88,15 @@ export const pack = async (
 
     await tgzUtils.extractArchiveTo(tgz, baseFs, { stripComponents: 1 })
     await copyRcFile(project, destination, report)
+    await copyProtocolFiles(project, destination, report, (descriptor) => {
+      if (!patchUtils.isPatchDescriptor(descriptor)) {
+        return undefined
+      }
+
+      const { parentLocator, patchPaths } = patchUtils.parseDescriptor(descriptor)
+
+      return { parentLocator, paths: patchPaths }
+    })
 
     if (project.configuration.get('yarnPath')) {
       await copyYarnRelease(project, destination, report)

--- a/yarn/pack-utils/src/patch-files/paths.ts
+++ b/yarn/pack-utils/src/patch-files/paths.ts
@@ -1,0 +1,62 @@
+import type { Descriptor }   from '@yarnpkg/core'
+import type { Project }      from '@yarnpkg/core'
+import type { Workspace }    from '@yarnpkg/core'
+import type { PortablePath } from '@yarnpkg/fslib'
+
+import { structUtils }       from '@yarnpkg/core'
+import { ppath }             from '@yarnpkg/fslib'
+import { patchUtils }        from '@yarnpkg/plugin-patch'
+
+const BUILTIN_REGEXP = /^builtin<([^>]+)>$/
+
+const getDescriptorPatchPaths = (descriptors: Iterable<Descriptor>): Array<PortablePath> => {
+  const paths = new Array<PortablePath>()
+
+  for (const descriptor of descriptors) {
+    if (!patchUtils.isPatchDescriptor(descriptor)) continue
+
+    const { patchPaths } = patchUtils.parseDescriptor(descriptor)
+
+    for (const rawPath of patchPaths) {
+      const flagIndex = rawPath.lastIndexOf('!')
+      const path = (flagIndex === -1 ? rawPath : rawPath.slice(flagIndex + 1)) as PortablePath
+
+      if (BUILTIN_REGEXP.test(path)) continue
+      if (ppath.isAbsolute(path)) continue
+
+      paths.push(path)
+    }
+  }
+
+  return paths
+}
+
+export const getWorkspacePatchPaths = (workspace: Workspace): Array<PortablePath> =>
+  getDescriptorPatchPaths([
+    ...workspace.manifest.dependencies.values(),
+    ...workspace.manifest.peerDependencies.values(),
+  ])
+
+export const getProjectResolutionPatchPaths = (project: Project): Array<PortablePath> =>
+  getDescriptorPatchPaths(
+    project.topLevelWorkspace.manifest.resolutions.map((resolution) => {
+      const ident = structUtils.parseIdent(resolution.pattern.descriptor.fullName)
+
+      return structUtils.makeDescriptor(ident, resolution.reference)
+    })
+  )
+
+export const resolvePatchPath = (
+  cwd: PortablePath,
+  path: PortablePath,
+  boundary: string
+): { relativePath: PortablePath; src: PortablePath } => {
+  const src = ppath.resolve(cwd, path)
+  const relativePath = ppath.contains(cwd, src)
+
+  if (relativePath === null) {
+    throw new Error(`Patch path ${path} resolves outside the ${boundary}`)
+  }
+
+  return { relativePath, src }
+}


### PR DESCRIPTION
## Task

- Close atls/raijin#813

## How to verify

### Before the fix

1. Context: an image-pack workspace with a Yarn patch dependency
   Action: run image pack
   Expected result: the standalone install fails with ENOENT because the patch resolution is preserved without its patch file

### After the fix

1. Context: the same workspace
   Action: run image pack with the committed Raijin runtime
   Expected result: workspace-relative patches are included in their owning workspace archives, project-root patches are materialized at the standalone root, and the standalone install completes

## Proofs

- Package tests and checks

```text
yarn test unit yarn/pack-utils/src/pack.utils.test.ts --test-reporter=tap -> 13 passed
targeted format / typecheck / lint -> passed
yarn raijin:check -> passed
yarn check -> passed
```

- Standalone patch contract

```text
optional!~/.yarn/patches path -> copied from the project root
top-level resolution patch path -> copied from the project root
reachable workspace ~/ patch path -> copied from the project root
workspace-relative patch path -> included in the owning workspace pack
workspace patch excluded by the files manifest -> included in the owning workspace pack
workspace path escaping its pack boundary -> rejected
same relative project/workspace path -> preserved in separate artifacts
patch descriptors outside the packed dependency graph -> ignored
non-workspace patch parent -> left to Yarn package resolution
```

- Committed runtime and standalone export

```text
yarn workspace @atls/yarn-cli build -> passed
cmp yarn/cli/dist/runtime/yarn.mjs .yarn/releases/yarn.mjs -> equal
yarn workspace @atls/yarn-pack-utils export --destination <temp> -> passed
required root-resolution .yarn/patches files -> present
unrelated workspace patch file -> absent
standalone Yarn resolution / fetch / link -> passed
```

- Revertix CMS integration smoke

```text
.yarn/patches/@strapi-core-npm-5.33.0-890f83b4d2.patch
Successfully built image cms-app-entrypoint
health_status=204
admin_status=200
running=true
```