### PR TITLE
fix(common): update esbuild wasm runtime

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6976,7 +6976,7 @@ const RAW_RUNTIME_STATE =
           ["clipanion", "virtual:b80567f1f726ad28b5f69c2f4d583115762754ed5e643c8ffc700d555267034c078163b8acf27ac9e54b95573c3afeb591dde0dc0755beb1e2c159d60551a612#npm:4.0.0-rc.2"],\
           ["esbuild", [\
             "esbuild-wasm",\
-            "npm:0.23.1"\
+            "npm:0.24.0"\
           ]],\
           ["semver", "npm:7.6.3"],\
           ["tslib", "npm:2.8.1"]\
@@ -10947,13 +10947,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["esbuild-wasm", [\
-      ["npm:0.23.1", {\
-        "packageLocation": "../.yarn/berry/cache/esbuild-wasm-npm-0.23.1-bc60c5041a-10.zip/node_modules/esbuild-wasm/",\
-        "packageDependencies": [\
-          ["esbuild-wasm", "npm:0.23.1"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:0.24.0", {\
         "packageLocation": "../.yarn/berry/cache/esbuild-wasm-npm-0.24.0-df844cf64e-10.zip/node_modules/esbuild-wasm/",\
         "packageDependencies": [\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -328,7 +328,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/builder", "https://github.com/TorinAsakura/yarnpkg-builder.git#commit=05a30e58225e52c7fa61664aa939f1fd7fedb7b6"],\
           ["esbuild", [\
             "esbuild-wasm",\
-            "npm:0.23.1"\
+            "npm:0.24.0"\
           ]],\
           ["prettier", "npm:3.5.3"],\
           ["react", "npm:18.3.1"],\
@@ -10953,6 +10953,13 @@ const RAW_RUNTIME_STATE =
           ["esbuild-wasm", "npm:0.23.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:0.24.0", {\
+        "packageLocation": "../.yarn/berry/cache/esbuild-wasm-npm-0.24.0-df844cf64e-10.zip/node_modules/esbuild-wasm/",\
+        "packageDependencies": [\
+          ["esbuild-wasm", "npm:0.24.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["escalade", [\
@@ -16328,7 +16335,7 @@ const RAW_RUNTIME_STATE =
           ["@yarnpkg/builder", "https://github.com/TorinAsakura/yarnpkg-builder.git#commit=05a30e58225e52c7fa61664aa939f1fd7fedb7b6"],\
           ["esbuild", [\
             "esbuild-wasm",\
-            "npm:0.23.1"\
+            "npm:0.24.0"\
           ]],\
           ["prettier", "npm:3.5.3"],\
           ["react", "npm:18.3.1"],\

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@atls/raijin": "workspace:*",
     "@types/node": "24.12.2",
     "@yarnpkg/builder": "https://github.com/TorinAsakura/yarnpkg-builder.git#commit=05a30e58225e52c7fa61664aa939f1fd7fedb7b6",
-    "esbuild": "npm:esbuild-wasm@^0.23.1",
+    "esbuild": "npm:esbuild-wasm@0.24.0",
     "prettier": "3.5.3",
     "react": "18.3.1",
     "typescript": "5.9.3"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "resolutions": {
     "@yarnpkg/builder": "https://github.com/TorinAsakura/yarnpkg-builder.git#commit=05a30e58225e52c7fa61664aa939f1fd7fedb7b6",
     "clipanion": "4.0.0-rc.2",
+    "esbuild@npm:esbuild-wasm@^0.23.0": "npm:esbuild-wasm@0.24.0",
     "eslint": "9.14.0",
     "flatted@npm:^3.2.7": "patch:flatted@npm%3A3.2.7#./.yarn/patches/flatted-npm-3.2.7-0da10b7c56.patch",
     "ink": "3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7259,7 +7259,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:esbuild-wasm@^0.23.0, esbuild@npm:esbuild-wasm@^0.23.1":
+"esbuild@npm:esbuild-wasm@0.24.0":
+  version: 0.24.0
+  resolution: "esbuild-wasm@npm:0.24.0"
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10/73353a7256a235d819652ad6dc41a4f6a68ea5b96f8ee926eb6eaf59b2d58ef163488505fe8e3850f6f20c18e9afe217120c36a7e1a35faa254891bc57cff472
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:esbuild-wasm@^0.23.0":
   version: 0.23.1
   resolution: "esbuild-wasm@npm:0.23.1"
   bin:
@@ -11962,7 +11971,7 @@ __metadata:
     "@atls/raijin": "workspace:*"
     "@types/node": "npm:24.12.2"
     "@yarnpkg/builder": "https://github.com/TorinAsakura/yarnpkg-builder.git#commit=05a30e58225e52c7fa61664aa939f1fd7fedb7b6"
-    esbuild: "npm:esbuild-wasm@^0.23.1"
+    esbuild: "npm:esbuild-wasm@0.24.0"
     prettier: "npm:3.5.3"
     react: "npm:18.3.1"
     typescript: "npm:5.9.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7268,15 +7268,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:esbuild-wasm@^0.23.0":
-  version: 0.23.1
-  resolution: "esbuild-wasm@npm:0.23.1"
-  bin:
-    esbuild: bin/esbuild
-  checksum: 10/30677e4ea96211d15f7b3780d70ecee564267767bc4465ba6539f57b565f2505ab930ca409d7b85695b5931fc37afb508f62c694c2e2092dd519efdecf62959b
-  languageName: node
-  linkType: hard
-
 "escalade@npm:^3.1.1, escalade@npm:^3.2.0":
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"


### PR DESCRIPTION
## Task

- Close atls/raijin#820

## How to verify

### Before the fix

1. Context: repository checkout using `esbuild-wasm@0.23.1`
   Action: run `yarn workspace @atls/yarn-cli build`
   Expected result: the build terminates with `slice bounds out of range [:-4294967295]` while printing PnP zip dependency paths

### After the fix

1. Context: this branch using the pinned `esbuild-wasm@0.24.0`
   Action: run `yarn workspace @atls/yarn-cli build`
   Expected result: the CLI build completes without the Go/WASM printer panic

## Proofs

- `yarn workspace @atls/yarn-cli build` completes successfully
- full `yarn check` completes successfully
- `yarn version check` completes successfully
- `git diff --check` completes successfully
