### PR TITLE
feat(raijin): add image tag aliases

### DIFF
--- a/code/code-pack/src/index.ts
+++ b/code/code-pack/src/index.ts
@@ -3,5 +3,6 @@ import * as tagUtils from './tag.utils.js'
 export type * from './pack.interfaces.js'
 export *      from './tag.utils.js'
 export *      from './pack.js'
+export *      from './pack-tags.utils.js'
 
 export { tagUtils }

--- a/code/code-pack/src/pack-tags.utils.ts
+++ b/code/code-pack/src/pack-tags.utils.ts
@@ -1,0 +1,21 @@
+const IMAGE_TAG_ALIAS_REGEXP = /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$/
+
+export const normalizeAdditionalTags = (tags: Array<string> = []): Array<string> => {
+  for (const tag of tags) {
+    if (!IMAGE_TAG_ALIAS_REGEXP.test(tag)) {
+      throw new Error(`Invalid image tag alias "${tag}".`)
+    }
+  }
+
+  return tags
+}
+
+export const getPackImageTags = (
+  image: string,
+  primaryTag: string,
+  additionalTags: Array<string> = []
+): Array<string> => [
+  `${image}:${primaryTag}`,
+  `${image}:latest`,
+  ...normalizeAdditionalTags(additionalTags).map((tag) => `${image}:${tag}`),
+]

--- a/code/code-pack/src/pack.interfaces.ts
+++ b/code/code-pack/src/pack.interfaces.ts
@@ -7,6 +7,7 @@ export interface PackOptions {
   builder: string
   buildpack: string
   tagPolicy: TagPolicy
+  additionalTags?: Array<string>
   platform?: string
   require?: Array<string>
   cwd?: PortablePath

--- a/code/code-pack/src/pack.ts
+++ b/code/code-pack/src/pack.ts
@@ -10,6 +10,8 @@ import { xfs }                     from '@yarnpkg/fslib'
 import { ppath }                   from '@yarnpkg/fslib'
 
 import { createProjectDescriptor } from './pack-descriptor.utils.js'
+import { getPackImageTags }        from './pack-tags.utils.js'
+import { normalizeAdditionalTags } from './pack-tags.utils.js'
 import { execOrThrow }             from './pack.utils.js'
 import { installPack }             from './pack.utils.js'
 import { getTag }                  from './tag.utils.js'
@@ -24,6 +26,7 @@ export const pack = async (
     buildpack,
     platform,
     require,
+    additionalTags,
     cwd,
   }: PackOptions,
   context: execUtils.PipevpOptions
@@ -64,24 +67,29 @@ export const pack = async (
 
   await xfs.writeFilePromise(descriptorPath, stringify(descriptor))
 
+  const imageTags = getPackImageTags(image, tag, additionalTags)
+  const [primaryImageTag, ...extraImageTags] = imageTags
+
   // eslint-disable-next-line no-console, n/no-sync
   console.debug('project.toml', readFileSync(descriptorPath, 'utf8'))
 
   const args = [
     'build',
     '--trust-builder',
-    `${image}:${tag}`,
+    primaryImageTag,
     '--descriptor',
     descriptorPath,
     '--buildpack',
     buildpack,
-    '--tag',
-    `${image}:latest`,
     '--creation-time',
     'now',
     '--clear-cache',
     '--verbose',
   ]
+
+  for (const imageTag of extraImageTags) {
+    args.push('--tag', imageTag)
+  }
 
   if (publish) {
     args.push('--publish')
@@ -113,8 +121,8 @@ export const pack = async (
   })
 
   return {
-    images: [`${image}:${tag}`, `${image}:latest`],
-    tags: [tag, 'latest'],
+    images: imageTags,
+    tags: [tag, 'latest', ...normalizeAdditionalTags(additionalTags)],
     workspace,
   }
 }

--- a/code/code-pack/unit/pack-tags-utils.test.ts
+++ b/code/code-pack/unit/pack-tags-utils.test.ts
@@ -1,0 +1,32 @@
+import assert                      from 'node:assert/strict'
+import test                        from 'node:test'
+
+import { getPackImageTags }        from '../src/pack-tags.utils.js'
+import { normalizeAdditionalTags } from '../src/pack-tags.utils.js'
+
+test('should keep default computed and latest tags', () => {
+  assert.deepEqual(getPackImageTags('registry.example.com/app', 'revision'), [
+    'registry.example.com/app:revision',
+    'registry.example.com/app:latest',
+  ])
+})
+
+test('should append additional image tag aliases', () => {
+  assert.deepEqual(
+    getPackImageTags('registry.example.com/app', 'revision', ['stage', 'production']),
+    [
+      'registry.example.com/app:revision',
+      'registry.example.com/app:latest',
+      'registry.example.com/app:stage',
+      'registry.example.com/app:production',
+    ]
+  )
+})
+
+test('should reject empty additional image tag alias', () => {
+  assert.throws(() => normalizeAdditionalTags(['']), /Invalid image tag alias/)
+})
+
+test('should reject image tag alias outside the supported safe subset', () => {
+  assert.throws(() => normalizeAdditionalTags(['stage/latest']), /Invalid image tag alias/)
+})

--- a/docs/raijin/commands.md
+++ b/docs/raijin/commands.md
@@ -233,6 +233,7 @@ Command map extracted from `yarn/plugin-*` and `@atls/yarn-cli` bundle
 - Contract: `packConfiguration.builderTag` selects the supported Node/buildpack channel.
 - Contract: `packConfiguration.buildpackVersion` pins an immutable buildpack tag for rollback.
 - Contract: `packConfiguration.buildpack` overrides the full buildpack reference.
+- Contract: `--tags <alias,...>` adds additional image tags to the same `pack build` invocation.
 - Plugin: `@atls/yarn-plugin-image`
 - Source: `yarn/plugin-image/sources/image-pack.command.ts`
 

--- a/docs/raijin/commands.ru.md
+++ b/docs/raijin/commands.ru.md
@@ -233,6 +233,7 @@
 - Контракт: `packConfiguration.builderTag` выбирает поддерживаемый Node/buildpack-канал.
 - Контракт: `packConfiguration.buildpackVersion` фиксирует неизменяемый buildpack tag для rollback.
 - Контракт: `packConfiguration.buildpack` переопределяет полную buildpack-ссылку.
+- Контракт: `--tags <alias,...>` добавляет дополнительные image tags в тот же вызов `pack build`.
 - Плагин: `@atls/yarn-plugin-image`
 - Исходник: `yarn/plugin-image/sources/image-pack.command.ts`
 

--- a/scripts/raijin/generate-artifacts.mjs
+++ b/scripts/raijin/generate-artifacts.mjs
@@ -82,12 +82,14 @@ const COMMAND_NOTES = {
       '`packConfiguration.builderTag` selects the supported Node/buildpack channel.',
       '`packConfiguration.buildpackVersion` pins an immutable buildpack tag for rollback.',
       '`packConfiguration.buildpack` overrides the full buildpack reference.',
+      '`--tags <alias,...>` adds additional image tags to the same `pack build` invocation.',
     ],
     ru: [
       '`packConfiguration` по умолчанию использует `ghcr.io/atls/buildpack-yarn-workspace:24`.',
       '`packConfiguration.builderTag` выбирает поддерживаемый Node/buildpack-канал.',
       '`packConfiguration.buildpackVersion` фиксирует неизменяемый buildpack tag для rollback.',
       '`packConfiguration.buildpack` переопределяет полную buildpack-ссылку.',
+      '`--tags <alias,...>` добавляет дополнительные image tags в тот же вызов `pack build`.',
     ],
   },
 }

--- a/yarn/plugin-image/sources/image-pack.command.ts
+++ b/yarn/plugin-image/sources/image-pack.command.ts
@@ -17,6 +17,7 @@ import { packUtils }                         from '@atls/yarn-pack-utils'
 import { resolveWorkspaceCommandContext }    from '@atls/yarn-plugin-tools/command-context'
 
 import { getDefaultMaterializationPlatform } from './image-pack.utils.js'
+import { parseAdditionalTags }               from './image-pack.utils.js'
 import { resolveBuildpackReference }         from './image-pack.utils.js'
 import { resolveBuilderReference }           from './image-pack.utils.js'
 
@@ -27,6 +28,8 @@ class ImagePackCommand extends BaseCommand {
 
   tagPolicy: TagPolicy = Option.String('-t,--tag-policy', 'revision')
 
+  tags: string = Option.String('--tags', '')
+
   publish: boolean = Option.Boolean('-p,--publish', false)
 
   platform?: string = Option.String('--platform')
@@ -34,6 +37,7 @@ class ImagePackCommand extends BaseCommand {
   async execute(): Promise<number> {
     const { configuration, project, workspace, workspaceCwd } =
       await resolveWorkspaceCommandContext(this.context.cwd, this.context.plugins)
+    const additionalTags = parseAdditionalTags(this.tags)
 
     const commandReport = await StreamReport.start(
       {
@@ -81,6 +85,7 @@ class ImagePackCommand extends BaseCommand {
             registry: this.registry,
             publish: this.publish,
             tagPolicy: this.tagPolicy,
+            additionalTags,
             buildpack: resolveBuildpackReference(packConfiguration),
             builder: resolveBuilderReference(packConfiguration),
             platform: this.platform,

--- a/yarn/plugin-image/sources/image-pack.utils.ts
+++ b/yarn/plugin-image/sources/image-pack.utils.ts
@@ -1,4 +1,6 @@
-import { arch } from 'node:os'
+import { arch }                    from 'node:os'
+
+import { normalizeAdditionalTags } from '@atls/code-pack'
 
 const DEFAULT_BUILDER_TAG = '24'
 const DEFAULT_BUILDER_IMAGE = 'atlantislab/builder-base'
@@ -17,6 +19,14 @@ export interface ImagePackConfiguration {
 
 export const getDefaultMaterializationPlatform = (): string =>
   `${DEFAULT_MATERIALIZATION_OS}/${arch()}`
+
+export const parseAdditionalTags = (tags: string): Array<string> => {
+  if (tags === '') {
+    return []
+  }
+
+  return normalizeAdditionalTags(tags.split(',').map((tag) => tag.trim()))
+}
 
 export const resolveBuildpackReference = ({
   buildpack,

--- a/yarn/plugin-image/sources/tests/image-pack.utils.test.ts
+++ b/yarn/plugin-image/sources/tests/image-pack.utils.test.ts
@@ -1,6 +1,7 @@
 import assert                        from 'node:assert/strict'
 import { test }                      from 'node:test'
 
+import { parseAdditionalTags }       from '../image-pack.utils.js'
 import { resolveBuildpackReference } from '../image-pack.utils.js'
 import { resolveBuilderReference }   from '../image-pack.utils.js'
 
@@ -58,4 +59,14 @@ test('should keep builder default and explicit override contract', () => {
     }),
     'registry.example.com/custom/builder:latest'
   )
+})
+
+test('should parse additional image tag aliases', () => {
+  assert.deepEqual(parseAdditionalTags(''), [])
+  assert.deepEqual(parseAdditionalTags('stage, production'), ['stage', 'production'])
+})
+
+test('should reject invalid additional image tag aliases', () => {
+  assert.throws(() => parseAdditionalTags('stage,,production'), /Invalid image tag alias/)
+  assert.throws(() => parseAdditionalTags('stage/latest'), /Invalid image tag alias/)
 })


### PR DESCRIPTION
## Task

- Close atls/raijin#864

## How to verify

### Main scenario

1. Context: `yarn image pack` CLI runtime
   Action: run `YARN_IGNORE_PATH=1 node yarn/cli/dist/runtime/yarn.mjs image pack --help`
   Expected result: usage includes `--tags #0` next to the existing registry, tag-policy, publish, and platform options

### Additional scenario

1. Context: invalid image tag aliases
   Action: run `YARN_IGNORE_PATH=1 node yarn/cli/dist/runtime/yarn.mjs image pack --tags stage,,production`
   Expected result: command fails before publication with `Invalid image tag alias "".`

## Proofs

- local checks

```text
yarn test unit pack-tags-utils image-pack.utils
yarn workspace @atls/code-pack build
yarn workspace @atls/yarn-plugin-image build
yarn raijin:generate
yarn cli:build
yarn check
yarn raijin:check
```
